### PR TITLE
Update the task group mapping and clean up the fetching from server.

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		F8C7D4162092CF36007490BC /* UIColor+BridgeKeyNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C7D4152092CF36007490BC /* UIColor+BridgeKeyNames.swift */; };
 		F8E4A4EF20A420380046577B /* SBAScheduleManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E4A4EE20A420380046577B /* SBAScheduleManagerTests.swift */; };
 		F8E4A4FB20A4D9F00046577B /* JSONDecoder+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E4A4FA20A4D9F00046577B /* JSONDecoder+Utilities.swift */; };
+		F8F063C320BF45C700DB7D9C /* BridgeSDK_Test.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8BF02B420B60F740016C343 /* BridgeSDK_Test.framework */; };
 		F8F7241E203D007800AC0E5B /* SurveyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F7241D203D007800AC0E5B /* SurveyTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -328,6 +329,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8F063C320BF45C700DB7D9C /* BridgeSDK_Test.framework in Frameworks */,
 				F83B44AF2032467D002825AE /* BridgeApp.framework in Frameworks */,
 				F875578D2080850900235078 /* Research_UnitTest.framework in Frameworks */,
 			);

--- a/BridgeApp/BridgeApp/Extensions/SBBScheduledActivity+Filters.swift
+++ b/BridgeApp/BridgeApp/Extensions/SBBScheduledActivity+Filters.swift
@@ -51,6 +51,21 @@ extension SBBScheduledActivity {
         return NSPredicate(day: date, dateKey: #keyPath(expiresOn))
     }
     
+    public static func notFinishedAvailableNowPredicate() -> NSPredicate {
+        let now = Date()
+        
+        let finishedKey = #keyPath(finishedOn)
+        let notFinishedPredicate = NSPredicate(format: "%K == nil", finishedKey)
+        
+        let expiredKey = #keyPath(expiresOn)
+        let expiredPredicate = NSPredicate(format: "%K == nil OR (%K >= %@)", expiredKey, expiredKey, now as CVarArg)
+        
+        let scheduledKey = #keyPath(scheduledOn)
+        let schedulePredicate = NSPredicate(format: "%K < %@", scheduledKey, now as CVarArg)
+        
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [schedulePredicate, notFinishedPredicate, expiredPredicate])
+    }
+    
     public static func availablePredicate(from scheduledFrom: Date, to scheduledTo: Date) -> NSPredicate {
         let finishedKey = #keyPath(finishedOn)
         let finishedPredicate = NSPredicate(format: "%K == nil OR ((%K >= %@) AND (%K < %@))", finishedKey, finishedKey, scheduledFrom as CVarArg, finishedKey, scheduledTo as CVarArg)
@@ -151,7 +166,12 @@ extension SBBScheduledActivity {
     }
     
     public static func finishedOnSortDescriptor(ascending: Bool) -> NSSortDescriptor {
-        let finishedKey = #keyPath(finishedOn)
-        return NSSortDescriptor(key: finishedKey, ascending: ascending)
+        let key = #keyPath(finishedOn)
+        return NSSortDescriptor(key: key, ascending: ascending)
+    }
+    
+    public static func scheduledOnSortDescriptor(ascending: Bool) -> NSSortDescriptor {
+        let key = #keyPath(scheduledOn)
+        return NSSortDescriptor(key: key, ascending: ascending)
     }
 }

--- a/BridgeApp/BridgeApp/Extensions/SBBScheduledActivity+Filters.swift
+++ b/BridgeApp/BridgeApp/Extensions/SBBScheduledActivity+Filters.swift
@@ -139,24 +139,27 @@ extension SBBScheduledActivity {
         return NSCompoundPredicate(orPredicateWithSubpredicates: [taskRefPredicate, surveyRefPredicate, comboRefPredicate])
     }
     
+    public static func activityGuidPredicate(with guid: String) -> NSPredicate {
+        return NSPredicate(format: "activity.guid == %@", guid)
+    }
+    
     public static func activityGroupPredicate(for activityGroup: SBAActivityGroup) -> NSPredicate {
         let identifiers = activityGroup.activityIdentifiers.map { $0.stringValue }
-        if let _ = activityGroup.schedulePlanGuidMap {
-            let predicates = identifiers.map { (identifier) -> NSPredicate in
-                let taskPredicate = SBBScheduledActivity.activityIdentifierPredicate(with: identifier)
-                if let guid = activityGroup.schedulePlanGuid(for: identifier) {
-                    let guidPredicate = SBBScheduledActivity.schedulePlanPredicate(with: guid)
-                    return NSCompoundPredicate(andPredicateWithSubpredicates: [guidPredicate, taskPredicate])
-                } else {
-                    return taskPredicate
+        if let guidMap = activityGroup.activityGuidMap {
+            let predicates: [NSPredicate] = identifiers.map {
+                if let guid = guidMap[$0] {
+                    return activityGuidPredicate(with: guid)
+                }
+                else {
+                    return activityIdentifierPredicate(with: $0)
                 }
             }
             return NSCompoundPredicate(orPredicateWithSubpredicates: predicates)
         }
         else {
-            let taskPredicate = SBBScheduledActivity.includeTasksPredicate(with: identifiers)
+            let taskPredicate = includeTasksPredicate(with: identifiers)
             if let guid = activityGroup.schedulePlanGuid {
-                let guidPredicate = SBBScheduledActivity.schedulePlanPredicate(with: guid)
+                let guidPredicate = schedulePlanPredicate(with: guid)
                 return NSCompoundPredicate(andPredicateWithSubpredicates: [guidPredicate, taskPredicate])
             }
             else {

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -149,7 +149,7 @@ open class SBABridgeConfiguration {
     
     /// Update the mapping by adding the given task.
     public func addMapping(with task: RSDTask) {
-        if self.activityInfoMap[task.identifier] == nil {
+        if !self.activityInfoMap.contains(where: { $0.value.moduleId?.stringValue == task.identifier })  {
             let activityInfo = SBAActivityInfoObject(identifier: RSDIdentifier(rawValue: task.identifier),
                                                      title: nil,
                                                      subtitle: nil,
@@ -267,8 +267,8 @@ public protocol SBAActivityGroup : RSDTaskGroup {
     /// The activity guid map that can be used to map scheduled activities to
     /// the appropriate group in the case where more than one group may contain
     /// the same tasks **but** where the activities are not all grouped on the server
-    /// using the same schedule. This guid can be found in the Bridge Manager UI by
-    /// hovering your cursor over the copy icon and selecting "Copy GUID".
+    /// using the same schedule. This guid can be found in the Bridge Study Manager UI
+    /// by hovering your cursor over the copy icon and selecting "Copy GUID".
     var activityGuidMap : [String : String]? { get }
 }
 
@@ -300,20 +300,6 @@ struct SBAActivityMappingObject : Decodable {
 ///
 /// - example:
 /// ````
-///    // Example activity group using a mapping of activity guid to .
-///    let json = """
-///            {
-///                "identifier": "foo",
-///                "title": "Title",
-///                "journeyTitle": "Journey title",
-///                "detail": "A detail about the object",
-///                "imageSource": "fooImage",
-///                "activityIdentifiers": ["taskA", "taskB", "taskC"],
-///                "notificationIdentifier": "scheduleFoo",
-///                "activityGuidMap": "abcdef12-3456-7890",
-///            }
-///            """.data(using: .utf8)! // our data in native (JSON) format
-///
 ///    // Example activity group using a shared `schedulePlanGuid`.
 ///    let json = """
 ///            {
@@ -324,6 +310,15 @@ struct SBAActivityMappingObject : Decodable {
 ///                "imageSource": "fooImage",
 ///                "activityIdentifiers": ["taskA", "taskB", "taskC"],
 ///                "notificationIdentifier": "scheduleFoo",
+///                "schedulePlanGuid": "abcdef12-3456-7890",
+///            }
+///            """.data(using: .utf8)! // our data in native (JSON) format
+///
+///    // Example activity group using the `activity.guid` identifiers to map schedules to tasks.
+///    let json = """
+///            {
+///                "identifier": "foo",
+///                "activityIdentifiers": ["taskA", "taskB", "taskC"],
 ///                "activityGuidMap": {
 ///                                     "taskA":"ababab12-3456-7890",
 ///                                     "taskB":"cdcdcd12-3456-7890",
@@ -331,6 +326,15 @@ struct SBAActivityMappingObject : Decodable {
 ///                                     }
 ///            }
 ///            """.data(using: .utf8)! // our data in native (JSON) format
+///
+///    // Example activity group where the first schedule matching the given activity identifer is used.
+///    let json = """
+///            {
+///                "identifier": "foo",
+///                "activityIdentifiers": ["taskA", "taskB", "taskC"]
+///            }
+///            """.data(using: .utf8)! // our data in native (JSON) format
+
 /// ````
 public struct SBAActivityGroupObject : Decodable, SBAOptionalImageVendor, SBAActivityGroup {
 
@@ -369,8 +373,8 @@ public struct SBAActivityGroupObject : Decodable, SBAOptionalImageVendor, SBAAct
     /// The activity guid map that can be used to map scheduled activities to
     /// the appropriate group in the case where more than one group may contain
     /// the same tasks **but** where the activities are not all grouped on the server
-    /// using the same schedule. This guid can be found in the Bridge Manager UI by
-    /// hovering your cursor over the copy icon and selecting "Copy GUID".
+    /// using the same schedule. This guid can be found in the Bridge Study Manager UI
+    /// by hovering your cursor over the copy icon and selecting "Copy GUID".
     public let activityGuidMap : [String : String]?
     
     private enum CodingKeys : String, CodingKey {

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -264,19 +264,12 @@ public protocol SBAActivityGroup : RSDTaskGroup {
     /// the same tasks.
     var schedulePlanGuid : String? { get }
     
-    /// The schedule plan guid map that can be used to map scheduled activities to
+    /// The activity guid map that can be used to map scheduled activities to
     /// the appropriate group in the case where more than one group may contain
     /// the same tasks **but** where the activities are not all grouped on the server
-    /// using the same schedule.
-    var schedulePlanGuidMap : [String : String]? { get }
-}
-
-extension SBAActivityGroup {
-    
-    /// Returns the schedule plan guid to use for a given activity identifier.
-    public func schedulePlanGuid(for identifier: String) -> String? {
-        return schedulePlanGuidMap?[identifier] ?? schedulePlanGuid
-    }
+    /// using the same schedule. This guid can be found in the Bridge Manager UI by
+    /// hovering your cursor over the copy icon and selecting "Copy GUID".
+    var activityGuidMap : [String : String]? { get }
 }
 
 /// Extend the task info protocol to include optional pointers for use by an `SBBTaskReference`
@@ -307,7 +300,7 @@ struct SBAActivityMappingObject : Decodable {
 ///
 /// - example:
 /// ````
-///    // Example activity group.
+///    // Example activity group using a mapping of activity guid to .
 ///    let json = """
 ///            {
 ///                "identifier": "foo",
@@ -317,7 +310,25 @@ struct SBAActivityMappingObject : Decodable {
 ///                "imageSource": "fooImage",
 ///                "activityIdentifiers": ["taskA", "taskB", "taskC"],
 ///                "notificationIdentifier": "scheduleFoo",
-///                "schedulePlanGuid": "abcdef12-3456-7890"
+///                "activityGuidMap": "abcdef12-3456-7890",
+///            }
+///            """.data(using: .utf8)! // our data in native (JSON) format
+///
+///    // Example activity group using a shared `schedulePlanGuid`.
+///    let json = """
+///            {
+///                "identifier": "foo",
+///                "title": "Title",
+///                "journeyTitle": "Journey title",
+///                "detail": "A detail about the object",
+///                "imageSource": "fooImage",
+///                "activityIdentifiers": ["taskA", "taskB", "taskC"],
+///                "notificationIdentifier": "scheduleFoo",
+///                "activityGuidMap": {
+///                                     "taskA":"ababab12-3456-7890",
+///                                     "taskB":"cdcdcd12-3456-7890",
+///                                     "taskC":"efefef12-3456-7890"
+///                                     }
 ///            }
 ///            """.data(using: .utf8)! // our data in native (JSON) format
 /// ````
@@ -355,14 +366,15 @@ public struct SBAActivityGroupObject : Decodable, SBAOptionalImageVendor, SBAAct
     /// the same tasks.
     public let schedulePlanGuid : String?
     
-    /// The schedule plan guid map that can be used to map scheduled activities to
+    /// The activity guid map that can be used to map scheduled activities to
     /// the appropriate group in the case where more than one group may contain
     /// the same tasks **but** where the activities are not all grouped on the server
-    /// using the same schedule.
-    public let schedulePlanGuidMap : [String : String]?
+    /// using the same schedule. This guid can be found in the Bridge Manager UI by
+    /// hovering your cursor over the copy icon and selecting "Copy GUID".
+    public let activityGuidMap : [String : String]?
     
     private enum CodingKeys : String, CodingKey {
-        case identifier, title, detail, journeyTitle, imageSource, activityIdentifiers, notificationIdentifier, schedulePlanGuid, schedulePlanGuidMap
+        case identifier, title, detail, journeyTitle, imageSource, activityIdentifiers, notificationIdentifier, schedulePlanGuid, activityGuidMap
     }
     
     /// Default initializer.
@@ -373,7 +385,7 @@ public struct SBAActivityGroupObject : Decodable, SBAOptionalImageVendor, SBAAct
                 activityIdentifiers : [RSDIdentifier],
                 notificationIdentifier : RSDIdentifier?,
                 schedulePlanGuid : String?,
-                schedulePlanGuidMap : [String : String]?) {
+                activityGuidMap : [String : String]?) {
         self.identifier = identifier
         self.title = title
         self.journeyTitle = journeyTitle
@@ -383,7 +395,7 @@ public struct SBAActivityGroupObject : Decodable, SBAOptionalImageVendor, SBAAct
         self.schedulePlanGuid = schedulePlanGuid
         self.detail = nil
         self.imageSource = nil
-        self.schedulePlanGuidMap = schedulePlanGuidMap
+        self.activityGuidMap = activityGuidMap
     }
     
     /// Returns nil. This task group is intended to allow using a shared codable configuration

--- a/BridgeApp/BridgeApp/Study Management/SBAParticipantManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAParticipantManager.swift
@@ -261,7 +261,7 @@ public final class SBAParticipantManager : NSObject {
     /// Convenience method for wrapping the call to BridgeSDK.
     fileprivate func fetchScheduledActivities(from fromDate: Date, to toDate: Date) {
         let pingDate = Date()
-        print("\n\n---Fetch schedules from:\(fromDate) to:\(toDate)")
+        //print("\n\n---Fetch schedules from:\(fromDate) to:\(toDate)")
         
         BridgeSDK.activityManager.getScheduledActivities(from: fromDate, to: toDate, cachingPolicy: .fallBackToCached) { (obj, error) in
             print("\n\n---Fetch Results pingDate:\(pingDate) from:\(fromDate) to:\(toDate) schedules:\(String(describing: obj))")

--- a/BridgeApp/BridgeApp/Study Management/SBAParticipantManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAParticipantManager.swift
@@ -64,9 +64,6 @@ public final class SBAParticipantManager : NSObject {
     /// Is the participant authenticated?
     public private(set) var isAuthenticated: Bool = false
     
-    /// The "first" day that the participant performed an activity for the study.
-    public private(set) var dayOne: Date?
-    
     /// Is this a test user?
     internal var isTestUser: Bool {
         return self.studyParticipant?.dataGroups?.contains("test_user") ?? false
@@ -82,50 +79,76 @@ public final class SBAParticipantManager : NSObject {
         super.init()
         
         // Add an observer for changes to the study participant.
-        NotificationCenter.default.addObserver(forName: .sbbUserSessionUpdated, object: nil, queue: .main) { (notification) in
+        NotificationCenter.default.addObserver(forName: .sbbUserSessionUpdated, object: nil, queue: self.updateQueue) { (notification) in
             guard let info = notification.userInfo?[kSBBUserSessionInfoKey] as? SBBUserSessionInfo else {
                 fatalError("Expecting a non-nil user session info")
             }
             let authenticated = info.authenticated?.boolValue ?? false
-            let hasChanges = (authenticated && !self.isAuthenticated) || !RSDObjectEquality(info.studyParticipant.dataGroups, self.studyParticipant?.dataGroups)
+            let hasChanges = (authenticated && !self.isAuthenticated) ||
+                !RSDObjectEquality(info.studyParticipant.dataGroups, self.studyParticipant?.dataGroups)
             self.studyParticipant = info.studyParticipant
             self.isAuthenticated = authenticated
             if hasChanges {
-                self.reloadSchedules()
+                self.reload(allFuture: true)
             }
         }
         
         // Add an observer that a schedule manager has updated the scheduled activities. Often updating the
         // schedules will change the available "next" schedule.
-        NotificationCenter.default.addObserver(forName: .SBADidSendUpdatedScheduledActivities, object: nil, queue: .main) { (notification) in
-            self.reloadSchedules()
+        NotificationCenter.default.addObserver(forName: .SBADidSendUpdatedScheduledActivities, object: nil, queue: self.updateQueue) { (notification) in
+            self.reload(allFuture: true)
         }
         
         // Add an observer the app entering the foreground to check for whether or not "today" is still valid.
-        NotificationCenter.default.addObserver(forName: .UIApplicationWillEnterForeground, object: nil, queue: .main) { (notification) in
-            self.reloadIfTodayChanged()
+        NotificationCenter.default.addObserver(forName: .UIApplicationWillEnterForeground, object: nil, queue: self.updateQueue) { (notification) in
+            self.reload(allFuture: false)
         }
     }
     
     // MARK: Shared schedule cache management.
     
+    private let userDefaultsQueue = DispatchQueue(label: "org.sagebionetworks.BridgeApp.SBAParticipantManager.UserDefaults")
+    private let updateQueue = OperationQueue()
+    
     /// Marks the start of today's date. This value is updated on a reload to update the current day.
     public private(set) var today = Date().startOfDay()
     
-    /// Tracking of the loading state.
-    public enum LoadState {
-        case firstLoad
-        case cachedLoad
-        case fromServer
+    /// Tracking for the last time the app pinged the server to update schedules.
+    public private(set) var lastPing: Date? {
+        get {
+            var ret: Date?
+            userDefaultsQueue.sync {
+                ret = UserDefaults.standard.object(forKey: "kSBALastPingTimestampKey") as? Date
+            }
+            return ret
+        }
+        set {
+            userDefaultsQueue.async {
+                UserDefaults.standard.set(newValue, forKey: "kSBALastPingTimestampKey")
+            }
+        }
     }
-    
-    /// State management for what the current loading state is. This is used to pre-load from cache before
-    /// going to the server for updates.
-    public private(set) var loadingState: LoadState = .firstLoad
+
+    /// The "first" day that the participant performed an activity for the study.
+    public private(set) var dayOne: Date? {
+        get {
+            var ret: Date?
+            userDefaultsQueue.sync {
+                ret = UserDefaults.standard.object(forKey: "kSBADayOneKey") as? Date
+            }
+            return ret
+        }
+        set {
+            userDefaultsQueue.async {
+                UserDefaults.standard.set(newValue, forKey: "kSBADayOneKey")
+            }
+        }
+    }
     
     /// State management for whether or not the schedules are reloading.
     public private(set) var isReloading: Bool = false
     fileprivate var _loadingBlocked: Bool = false
+    fileprivate var _timerReload: Bool = false
 
     /// Exit early if already reloading activities. This can happen if the user flips quickly back and forth
     /// from this tab to another tab.
@@ -141,92 +164,112 @@ public final class SBAParticipantManager : NSObject {
     
     /// Reload the schedules. This is triggered automatically by a change to data groups and when returning
     /// from the background.
-    public func reloadSchedules() {
-        DispatchQueue.main.async {
+    public func updateSchedules() {
+        self.updateQueue.addOperation {
             self.reload(allFuture: true)
         }
     }
     
-    private func reloadIfTodayChanged() {
-        DispatchQueue.main.async {
-            self.reload(allFuture: false)
-        }
-    }
-    
     private func reload(allFuture: Bool) {
-        guard (allFuture || Calendar.current.isDateInToday(self.today)),
+        guard self.isAuthenticated && (allFuture || !Calendar.current.isDateInToday(self.today)),
             shouldContinueLoading()
             else {
                 return
         }
         
-        let daysIntoFuture = allFuture ? BridgeSDK.bridgeInfo.cacheDaysAhead + 1 : 1
-        let toDate = Date().addingNumberOfDays(daysIntoFuture).startOfDay()
-        var fromDate = self.today
-        var cachingPolicy: SBBCachingPolicy = .fallBackToCached
-        self.today = Date().startOfDay()
-        if loadingState == .firstLoad {
-            fromDate = startStudy
-            cachingPolicy = .cachedOnly
-            loadingState = .cachedLoad
-        }
+        let daysIntoFuture = BridgeSDK.bridgeInfo.cacheDaysAhead + 1
+        var fromDate: Date = self.lastPing ?? self.startStudy
+        let toDate: Date = Date().addingNumberOfDays(daysIntoFuture).startOfDay()
         
-        fetchScheduledActivities(from: fromDate, to: toDate, cachingPolicy: cachingPolicy) { (activities, error) in
-            self.handleLoadedActivities(activities, from: fromDate, to: toDate, error: error)
+        if allFuture {
+            let predicate = SBBScheduledActivity.notFinishedAvailableNowPredicate()
+            let sortDescriptors = [SBBScheduledActivity.scheduledOnSortDescriptor(ascending: true)]
+            let schedules = try? BridgeSDK.activityManager.getCachedSchedules(using: predicate, sortDescriptors: sortDescriptors, fetchLimit: 1)
+            if let scheduledOn = schedules?.first?.scheduledOn, scheduledOn < fromDate {
+                // Found a schedule. Need to check if it is still valid.
+                fromDate = scheduledOn
+            }
         }
+
+        // Reset "today"
+        self.today = Date().startOfDay()
+        
+        fetchScheduledActivities(from: fromDate, to: toDate)
     }
 
     /// Some (but possibly not all) of the requested schedules have been fetched. Handle adding them and
     /// fetch more of the range if needed.
-    fileprivate func handleLoadedActivities(_ scheduledActivities: [SBBScheduledActivity]?, from fromDate: Date, to toDate: Date, error: Error?) {
-        DispatchQueue.main.async {
-            
-            // Mark the start of the participant's engagement in the study.
-            if let scheduledActivities = scheduledActivities {
-                
-                // Set the dayOne value.
-                if (self.dayOne == nil) || (fromDate < self.dayOne!) {
-                    let dayOne = scheduledActivities.compactMap{ $0.finishedOn }.sorted().first
-                    if (dayOne != nil) && ((self.dayOne == nil) || (dayOne! < self.dayOne!)) {
-                        SBAParticipantManager.shared.dayOne = dayOne
-                    }
-                }
-            
-                // Preload all the surveys so that they can be accessed offline.
-                var surveys: [String] = []
-                scheduledActivities.forEach {
-                    if let survey = $0.activity.survey, !surveys.contains(survey.href) {
-                        surveys.append(survey.href)
-                        BridgeSDK.surveyManager.getSurveyByRef(survey.href, cachingPolicy: .checkCacheFirst) { (_, _) in }
+    fileprivate func handleLoadedActivities(pingDate: Date, scheduledActivities: [SBBScheduledActivity]?, error: Error?) {
+        
+        self.isReloading = false
+        self._timerReload = false
+        
+        // Failed to ping server, try again in 5 minutes.
+        guard error == nil, let scheduledActivities = scheduledActivities else {
+            self._timerReload = true
+            let delay = DispatchTime.now() + .seconds(5 * 60)
+            DispatchQueue.main.asyncAfter(deadline: delay) {
+                self.updateQueue.addOperation {
+                    if !self.isReloading && self._timerReload {
+                        self.reload(allFuture: true)
                     }
                 }
             }
+            return
+        }
+        
+        // TODO: Remove debugging code once the caching thing is figured out.
+        //        #if DEBUG
+        //        do {
+        //            let schedules = try BridgeSDK.activityManager.getCachedSchedules(using: NSPredicate(value: true), sortDescriptors: nil, fetchLimit: 0)
+        //            print("\n---\nCached schedules AFTER server request:\n\(schedules)")
+        //        }
+        //        catch let err {
+        //            debugPrint("Error fetching cached results: \(err)")
+        //        }
+        //        #endif
+        
+        // Save the last ping date for a successful ping of the server.
+        self.lastPing = pingDate
             
-            if self.loadingState == .fromServer {
-                // If the loading state is for the full range, then we are done.
-                self.isReloading = false
-                
-                // Post notification that the schedules were updated.
-                NotificationCenter.default.post(name: .SBAFinishedUpdatingScheduleCache,
-                                                object: self)
+        // Set the dayOne value.
+        if (self.dayOne == nil) {
+            let dayOne = scheduledActivities.compactMap{ $0.finishedOn }.sorted().first
+            SBAParticipantManager.shared.dayOne = dayOne
+        }
+        
+        // Preload all the surveys so that they can be accessed offline.
+        var surveys: [String] = []
+        scheduledActivities.forEach {
+            if let survey = $0.activity.survey, !surveys.contains(survey.href) {
+                surveys.append(survey.href)
+                BridgeSDK.surveyManager.getSurveyByRef(survey.href, cachingPolicy: .checkCacheFirst) { (_, _) in }
             }
-            else {
-                // Otherwise, load more range from the server
-                self.loadingState = .fromServer
-                
-                let nextFromDate = (scheduledActivities?.count ?? 0 > 0) ? Date() : fromDate
-                
-                self.fetchScheduledActivities(from: nextFromDate, to: toDate, cachingPolicy: .fallBackToCached) { (activities, error) in
-                    self.handleLoadedActivities(activities, from: nextFromDate, to: toDate, error: error)
-                }
-            }
+        }
+
+        if self._loadingBlocked {
+            // If loading refresh was requested, but blocked, then reload again.
+            reload(allFuture: true)
+        }
+        else {
+            // We are done. Post notification that the schedules were updated.
+            NotificationCenter.default.post(name: .SBAFinishedUpdatingScheduleCache,
+                                            object: self)
         }
     }
     
     /// Convenience method for wrapping the call to BridgeSDK.
-    fileprivate func fetchScheduledActivities(from fromDate: Date, to toDate: Date, cachingPolicy policy: SBBCachingPolicy, completion: @escaping ([SBBScheduledActivity]?, Error?) -> Swift.Void) {
-        BridgeSDK.activityManager.getScheduledActivities(from: fromDate, to: toDate, cachingPolicy: policy) { (obj, error) in
-            completion(obj as? [SBBScheduledActivity], error)
+    fileprivate func fetchScheduledActivities(from fromDate: Date, to toDate: Date) {
+        let pingDate = Date()
+        print("\n\n---Fetch schedules from:\(fromDate) to:\(toDate)")
+        
+        BridgeSDK.activityManager.getScheduledActivities(from: fromDate, to: toDate, cachingPolicy: .fallBackToCached) { (obj, error) in
+            print("\n\n---Fetch Results pingDate:\(pingDate) from:\(fromDate) to:\(toDate) schedules:\(String(describing: obj))")
+            self.updateQueue.addOperation {
+                self.handleLoadedActivities(pingDate: pingDate,
+                                            scheduledActivities: obj as? [SBBScheduledActivity],
+                                            error: error)
+            }
         }
     }
 }

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
@@ -272,6 +272,7 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
     ///
     /// - parameter scheduledActivities: The list of activities returned by the service.
     open func update(fetchedActivities: [SBBScheduledActivity]) {
+        //print("\n\n--- Update called for \(self.identifier) with:\n\(fetchedActivities)")
         if (fetchedActivities != self.scheduledActivities) {
             self.scheduledActivities = fetchedActivities
             let previous = self.scheduledActivities
@@ -518,7 +519,7 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
             // If the task finished with an error or discarded results, then delete the output directory.
             taskController.taskPath.deleteOutputDirectory()
             if let err = error {
-                print("WARNING! Task failed: \(err)")
+                debugPrint("WARNING! Task failed: \(err)")
             }
         }
     }
@@ -526,17 +527,17 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
     /// Call from the view controller that is used to display the task when the task is ready to save.
     open func taskController(_ taskController: RSDTaskController, readyToSave taskPath: RSDTaskPath) {
         
-        // Archive and upload results. This is run on a background queue.
-        taskPath.archiveResults(with: self) {
-            // TODO: Implement completion handling if any?? syoung 05/24/2018
-        }
-        
-        // Update the schedule on the server but only if the survey was not ended early
+        // Update the schedule on the server but only if the survey was not ended early. In that case, only
+        // send the archive but do not mark the task as finished or update the data groups.
         if !taskPath.didExitEarly {
             self.offMainQueue.async {
                 self.updateDataGroups(for: taskPath)
                 self.updateSchedules(for: taskPath)
+                self.archiveAndUpload(taskPath: taskPath)
             }
+        }
+        else {
+            self.archiveAndUpload(taskPath: taskPath)
         }
     }
     
@@ -558,7 +559,7 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
         
         BridgeSDK.participantManager.updateDataGroups(withGroups: rule.currentCohorts) { (_, error) in
             if let err = error {
-                print("WARNING! Failed to update the data groups: \(err)")
+                debugPrint("WARNING! Failed to update the data groups: \(err)")
             }
         }
     }
@@ -584,7 +585,11 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
         }
         appendSchedule(for: taskPath)
 
-        self.sendUpdated(for: schedules)
+        // Send message to server that the scheduled activites were updated.
+        self.sendUpdated(for: schedules, taskPath: taskPath)
+        
+        // Post message to self that the scheduled activities were updated.
+        self.didUpdateScheduledActivities(from: self.scheduledActivities)
     }
     
     /// For each schedule that this task modifies, mark it as completed.
@@ -604,12 +609,11 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
     /// Send message to Bridge server to update the given schedules. This includes both the task
     /// that was completed and any tasks that were performed as a requirement of completion of the
     /// primary task (such as a required one-time survey).
-    open func sendUpdated(for schedules: [SBBScheduledActivity]) {
-        
-        // Post message to self that the scheduled activities were updated.
-        self.didUpdateScheduledActivities(from: self.scheduledActivities)
-        
+    open func sendUpdated(for schedules: [SBBScheduledActivity], taskPath: RSDTaskPath? = nil) {
         BridgeSDK.activityManager.updateScheduledActivities(schedules) { (_, _) in
+            
+            //print("\n\n--- Finished updating schedules: \(schedules)")
+            
             // Post notification that the schedules were updated.
             NotificationCenter.default.post(name: .SBADidSendUpdatedScheduledActivities,
                                             object: self,
@@ -617,6 +621,17 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
         }
     }
     
+    /// Archive and update the task results.
+    private func archiveAndUpload(taskPath: RSDTaskPath) {
+        // Archive and upload results.
+        let uuid = UUID()
+        self._retainedPaths[uuid] = taskPath
+        taskPath.archiveResults(with: self) {
+            self._retainedPaths[uuid] = nil
+        }
+    }
+    
+    private var _retainedPaths: [UUID : RSDTaskPath] = [:]
     
     // MARK: RSDDataArchiveManager
     
@@ -721,5 +736,3 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
     }
     #endif
 }
-
-

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
@@ -431,9 +431,15 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
         
         // Set up predicates.
         var taskPredicate = SBBScheduledActivity.activityIdentifierPredicate(with: taskInfo.identifier)
-        if let guid = (activityGroup ?? self.activityGroup)?.schedulePlanGuid(for: taskInfo.identifier) {
-            taskPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-                taskPredicate, SBBScheduledActivity.schedulePlanPredicate(with: guid)])
+        if let group = (activityGroup ?? self.activityGroup) {
+            if let guid = group.schedulePlanGuid {
+                taskPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    taskPredicate, SBBScheduledActivity.schedulePlanPredicate(with: guid)])
+            }
+            else if let guid = group.activityGuidMap?[taskInfo.identifier] {
+                taskPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    taskPredicate, SBBScheduledActivity.activityGuidPredicate(with: guid)])
+            }
         }
 
         // Get the schedule.

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
@@ -627,16 +627,18 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager {
         }
     }
     
-    /// Archive and update the task results.
-    private func archiveAndUpload(taskPath: RSDTaskPath) {
-        // Archive and upload results.
+    /// Archive and upload results.
+    ///
+    /// DO NOT MAKE OPEN. This method retains the task path until archiving is completed and because it
+    /// nils out the pointer to the task path with a strong reference to `self`, it will also retain the
+    /// schedule manager until the completion block is called. syoung 05/31/2018
+    private final func archiveAndUpload(taskPath: RSDTaskPath) {
         let uuid = UUID()
         self._retainedPaths[uuid] = taskPath
         taskPath.archiveResults(with: self) {
             self._retainedPaths[uuid] = nil
         }
     }
-    
     private var _retainedPaths: [UUID : RSDTaskPath] = [:]
     
     // MARK: RSDDataArchiveManager

--- a/BridgeApp/BridgeAppTests/ActivityReferenceTests.swift
+++ b/BridgeApp/BridgeAppTests/ActivityReferenceTests.swift
@@ -238,6 +238,49 @@ class ActivityReferenceTests: XCTestCase {
         }
     }
     
+    func testActivityGroup2_Codable() {
+        
+    let json = """
+            {
+                "identifier": "foo",
+                "title": "Title",
+                "journeyTitle": "Journey title",
+                "detail": "A detail about the object",
+                "imageSource": "fooImage",
+                "activityIdentifiers": ["taskA", "taskB", "taskC"],
+                "notificationIdentifier": "scheduleFoo",
+                "activityGuidMap": {
+                                     "taskA":"ababab12-3456-7890",
+                                     "taskB":"cdcdcd12-3456-7890",
+                                     "taskC":"efefef12-3456-7890"
+                                     }
+            }
+            """.data(using: .utf8)! // our data in native (JSON) format
+        
+        do {
+            let object = try decoder.decode(SBAActivityGroupObject.self, from: json)
+            
+            XCTAssertEqual(object.identifier, "foo")
+            XCTAssertEqual(object.title, "Title")
+            XCTAssertEqual(object.journeyTitle, "Journey title")
+            XCTAssertEqual(object.detail, "A detail about the object")
+            XCTAssertEqual(object.imageSource?.imageName, "fooImage")
+            let expectedIdentifiers: [RSDIdentifier] = ["taskA", "taskB", "taskC"]
+            XCTAssertEqual(object.activityIdentifiers, expectedIdentifiers)
+            XCTAssertEqual(object.notificationIdentifier, "scheduleFoo")
+            let expectedMap = [
+                "taskA":"ababab12-3456-7890",
+                "taskB":"cdcdcd12-3456-7890",
+                "taskC":"efefef12-3456-7890"
+            ]
+            XCTAssertEqual(object.activityGuidMap, expectedMap)
+            
+        } catch let err {
+            XCTFail("Failed to decode/encode object: \(err)")
+            return
+        }
+    }
+    
     func testActivityGroup_Codable_Default() {
         
         // Test that decoding a default object without any nullable proprties doesn't fail.

--- a/BridgeApp/BridgeAppTests/BridgeAppTests-Bridging-Header.h
+++ b/BridgeApp/BridgeAppTests/BridgeAppTests-Bridging-Header.h
@@ -32,3 +32,4 @@
 //
 
 @import Research_UnitTest;
+@import BridgeSDK_Test;


### PR DESCRIPTION
Update the design to not bother looking at the cache but only fetch **everything**. This will be slow for a user who is re-installing an app with a long history of data, but otherwise, it's less yoga.

Also, this addresses the issue of having a task group created by referencing schedules in different schedule plans.