### PR TITLE
Fix the data tracking so that a second run of the task doesn’t include the selection result.

### DIFF
--- a/BridgeApp/BridgeApp/Data Tracking/Model/SBATrackedItemsLoggingStepObject.swift
+++ b/BridgeApp/BridgeApp/Data Tracking/Model/SBATrackedItemsLoggingStepObject.swift
@@ -168,6 +168,11 @@ public struct SBATrackedLoggingCollectionResultObject : RSDCollectionResult, Cod
         return try self.rsd_jsonEncodedDictionary() as NSDictionary
     }
     
+    /// Returns `false` to save the results of previous runs.
+    public func shouldReplacePreviousClientData() -> Bool {
+        return false
+    }
+    
     /// Update the selection from the client data.
     mutating public func updateSelected(from clientData: SBBJSONValue, with items: [SBATrackedItem]) throws {
         guard let dictionary = (clientData as? NSDictionary) ?? (clientData as? [NSDictionary])?.last

--- a/BridgeApp/BridgeApp/Data Tracking/Model/SBATrackedItemsLoggingStepObject.swift
+++ b/BridgeApp/BridgeApp/Data Tracking/Model/SBATrackedItemsLoggingStepObject.swift
@@ -160,6 +160,11 @@ public struct SBATrackedLoggingCollectionResultObject : RSDCollectionResult, Cod
     
     /// Build the client data for this result.
     public func clientData() throws -> SBBJSONValue? {
+        // Only include the client data for the logging result and not the selection result.
+        guard identifier == SBATrackedItemsStepNavigator.StepIdentifiers.logging.stringValue
+            else {
+                return nil
+        }
         return try self.rsd_jsonEncodedDictionary() as NSDictionary
     }
     

--- a/BridgeApp/BridgeApp/Research Model/SBAClientDataResult.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBAClientDataResult.swift
@@ -39,4 +39,7 @@ public protocol SBAClientDataResult : RSDResult, RSDArchivable {
     
     /// Build the client data object appropriate to this result.
     func clientData() throws -> SBBJSONValue?
+    
+    /// Should the previous client data object be replace with this one?
+    func shouldReplacePreviousClientData() -> Bool
 }

--- a/BridgeApp/BridgeApp/Research Model/SBAClientDataResult.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBAClientDataResult.swift
@@ -40,6 +40,6 @@ public protocol SBAClientDataResult : RSDResult, RSDArchivable {
     /// Build the client data object appropriate to this result.
     func clientData() throws -> SBBJSONValue?
     
-    /// Should the previous client data object be replace with this one?
+    /// Should the previous client data object be replaced with this one?
     func shouldReplacePreviousClientData() -> Bool
 }

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -334,7 +334,6 @@ struct SBAActivityMappingObject : Decodable {
 ///                "activityIdentifiers": ["taskA", "taskB", "taskC"]
 ///            }
 ///            """.data(using: .utf8)! // our data in native (JSON) format
-
 /// ````
 public struct SBAActivityGroupObject : Decodable, SBAOptionalImageVendor, SBAActivityGroup {
 

--- a/BridgeApp/BridgeApp/Study Management/SBAParticipantManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAParticipantManager.swift
@@ -218,17 +218,6 @@ public final class SBAParticipantManager : NSObject {
             return
         }
         
-        // TODO: Remove debugging code once the caching thing is figured out.
-        //        #if DEBUG
-        //        do {
-        //            let schedules = try BridgeSDK.activityManager.getCachedSchedules(using: NSPredicate(value: true), sortDescriptors: nil, fetchLimit: 0)
-        //            print("\n---\nCached schedules AFTER server request:\n\(schedules)")
-        //        }
-        //        catch let err {
-        //            debugPrint("Error fetching cached results: \(err)")
-        //        }
-        //        #endif
-        
         // Save the last ping date for a successful ping of the server.
         self.lastPing = pingDate
             
@@ -261,10 +250,8 @@ public final class SBAParticipantManager : NSObject {
     /// Convenience method for wrapping the call to BridgeSDK.
     fileprivate func fetchScheduledActivities(from fromDate: Date, to toDate: Date) {
         let pingDate = Date()
-        //print("\n\n---Fetch schedules from:\(fromDate) to:\(toDate)")
-        
         BridgeSDK.activityManager.getScheduledActivities(from: fromDate, to: toDate, cachingPolicy: .fallBackToCached) { (obj, error) in
-            print("\n\n---Fetch Results pingDate:\(pingDate) from:\(fromDate) to:\(toDate) schedules:\(String(describing: obj))")
+            // print("\n\n---Fetch Results pingDate:\(pingDate) from:\(fromDate) to:\(toDate)\n\(String(describing: obj))")
             self.updateQueue.addOperation {
                 self.handleLoadedActivities(pingDate: pingDate,
                                             scheduledActivities: obj as? [SBBScheduledActivity],


### PR DESCRIPTION
Fix client data for a result should only be included if the result is for logging and **not** if the result is the result of the selection step. For repeat visits to the same task, the selection result is included using the selection identifier.

For medication tracking, the results for subsequent visits need to include consolidated results for the whole day. 