### PR TITLE
Refactor task identifier -> schema identifier mapping

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		F886FD2F2035248600EF2248 /* SBBScheduledActivity+Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886FD2E2035248600EF2248 /* SBBScheduledActivity+Filters.swift */; };
 		F886FD31203524C600EF2248 /* Date+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = F886FD30203524C600EF2248 /* Date+Utilities.swift */; };
 		F886FD342036067300EF2248 /* BridgeApp.strings in Resources */ = {isa = PBXBuildFile; fileRef = F886FD332036067300EF2248 /* BridgeApp.strings */; };
+		F899D0E520D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F899D0E420D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift */; };
 		F89B3DEA20C6F647002EAE2D /* Sequence+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89B3DE920C6F647002EAE2D /* Sequence+Utilities.swift */; };
 		F89B3DEC20C7155D002EAE2D /* SBAMedicationLoggingStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89B3DEB20C7155D002EAE2D /* SBAMedicationLoggingStepObject.swift */; };
 		F89F676A2032789800B5CC4B /* StepProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89F67692032789800B5CC4B /* StepProtocolTests.swift */; };
@@ -300,6 +301,7 @@
 		F886FD2E2035248600EF2248 /* SBBScheduledActivity+Filters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SBBScheduledActivity+Filters.swift"; sourceTree = "<group>"; };
 		F886FD30203524C600EF2248 /* Date+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Utilities.swift"; sourceTree = "<group>"; };
 		F886FD332036067300EF2248 /* BridgeApp.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = BridgeApp.strings; sourceTree = "<group>"; };
+		F899D0E420D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SBBScheduledActivity+ResearchModel.swift"; sourceTree = "<group>"; };
 		F89B3DE920C6F647002EAE2D /* Sequence+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Utilities.swift"; sourceTree = "<group>"; };
 		F89B3DEB20C7155D002EAE2D /* SBAMedicationLoggingStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBAMedicationLoggingStepObject.swift; sourceTree = "<group>"; };
 		F89F67692032789800B5CC4B /* StepProtocolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StepProtocolTests.swift; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 				F89F676B203279EF00B5CC4B /* SBBSurveyElement+RSDStep.swift */,
 				F80F175E2033980300352C3E /* SBBSurveyRule+RSDSurveyRule.swift */,
 				F80F17A22033CB1B00352C3E /* SBBSurvey+RSDTask.swift */,
+				F899D0E420D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift */,
 			);
 			path = "Research Model";
 			sourceTree = "<group>";
@@ -984,6 +987,7 @@
 				F89F676E20327A8700B5CC4B /* SBASurveyConfiguration.swift in Sources */,
 				F886FD2F2035248600EF2248 /* SBBScheduledActivity+Filters.swift in Sources */,
 				F8E4A4FB20A4D9F00046577B /* JSONDecoder+Utilities.swift in Sources */,
+				F899D0E520D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift in Sources */,
 				F886FD1320351E1E00EF2248 /* SBBActivity+RSDTaskInfo.swift in Sources */,
 				F8C7D4162092CF36007490BC /* UIColor+BridgeKeyNames.swift in Sources */,
 				F82B1A9E20363DD500FEA16D /* SBBScheduledActivity+Utilities.swift in Sources */,

--- a/BridgeApp/BridgeApp/Research Model/SBAActivityReference.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBAActivityReference.swift
@@ -62,7 +62,7 @@ extension SBAActivityReference {
     
     /// Return the activity info from the configuration map.
     public var activityInfo : SBAActivityInfo? {
-        return SBABridgeConfiguration.shared.activityInfoMap[identifier]
+        return SBABridgeConfiguration.shared.activityInfo(for: self.identifier)
     }
     
     /// Return the activity info title.
@@ -146,7 +146,7 @@ extension SBBSchemaReference : SBASingleActivityReference, RSDSchemaInfo {
 extension SBBTaskReference : SBASingleActivityReference {
     
     public var schemaInfo: RSDSchemaInfo? {
-        return SBABridgeConfiguration.shared.schemaReferenceMap[self.identifier]
+        return SBABridgeConfiguration.shared.schemaInfo(for: self.identifier)
     }
 }
 

--- a/BridgeApp/BridgeApp/Research Model/SBBScheduledActivity+ResearchModel.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBBScheduledActivity+ResearchModel.swift
@@ -1,0 +1,44 @@
+//
+//  SBBScheduledActivity+ResearchModel.swift
+//  BridgeApp (iOS)
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+extension SBBScheduledActivity {
+    
+    public var schemaInfo : RSDSchemaInfo? {
+        guard let activityIdentifier = self.activityIdentifier else {
+            return nil
+        }
+        return SBABridgeConfiguration.shared.schemaInfo(for: activityIdentifier)
+    }
+}

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -42,10 +42,10 @@ open class SBABridgeConfiguration {
     /// The shared singleton.
     public static var shared = SBABridgeConfiguration()
     
-    /// A mapping of the activity groups defined for this application to their identifier.
+    /// A mapping of identifiers to activity groups defined for this application.
     fileprivate var activityGroupMap : [String : SBAActivityGroup] = [:]
     
-    /// A mapping of the activity infos defined for this application to their activity identifier.
+    /// A mapping of activity identifiers to activity infos defined for this application.
     fileprivate var activityInfoMap : [String : SBAActivityInfo] = [:]
     
     /// A mapping of schema identifier to schema references.

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -130,11 +130,6 @@ open class SBABridgeConfiguration {
         }
     }
     
-    /// Get the activity group with the given identifier.
-    open func activityGroup(with identifier: String) -> SBAActivityGroup? {
-        return activityGroupMap[identifier]
-    }
-    
     /// Update the mapping by adding the given activity info.
     open func addMapping(with activityInfo: SBAActivityInfo) {
         self.activityInfoMap[activityInfo.identifier] = activityInfo
@@ -248,6 +243,16 @@ open class SBABridgeConfiguration {
         } else {
             return storedTask
         }
+    }
+    
+    /// Listing of all the installed activity groups.
+    open var installedGroups: [SBAActivityGroup] {
+        return self.activityGroupMap.values.map { $0 }
+    }
+    
+    /// Get the activity group with the given identifier.
+    open func activityGroup(with identifier: String) -> SBAActivityGroup? {
+        return activityGroupMap[identifier]
     }
     
     /// Look for a task info object in the mapping tables for the given activity reference.

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -42,20 +42,20 @@ open class SBABridgeConfiguration {
     /// The shared singleton.
     public static var shared = SBABridgeConfiguration()
     
-    /// A mapping of the activity groups defined for this application.
-    open var activityGroups : [SBAActivityGroup] = []
+    /// A mapping of the activity groups defined for this application to their identifier.
+    fileprivate var activityGroupMap : [String : SBAActivityGroup] = [:]
     
-    /// A mapping of the activity infos defined for this application.
-    open var activityInfoMap : [String : SBAActivityInfo] = [:]
+    /// A mapping of the activity infos defined for this application to their activity identifier.
+    fileprivate var activityInfoMap : [String : SBAActivityInfo] = [:]
     
-    /// A mapping of schema references.
-    open var schemaReferenceMap : [String : SBBSchemaReference] = [:]
+    /// A mapping of schema identifier to schema references.
+    fileprivate var schemaReferenceMap: [String : SBBSchemaReference] = [:]
     
-    /// A mapping of tasks to an identifier.
-    open var taskMap : [String : RSDTask] = [:]
+    /// A mapping of activity identifiers to tasks.
+    fileprivate var taskMap : [String : RSDTask] = [:]
     
-    /// A mapping of schema identifiers to task identifiers.
-    open var schemaIdentifierMap : [String : SBAModuleIdentifier] = [:]
+    /// A mapping of task identifier to schema identifier.
+    fileprivate var taskToSchemaIdentifierMap : [String : String] = [:]
     
     /// The duration of the study. Default = 1 year.
     open var studyDuration : DateComponents = {
@@ -100,15 +100,18 @@ open class SBABridgeConfiguration {
     
     /// Decode the `clientData`, schemas, and surveys for this application.
     open func setup(with appConfig: SBBAppConfig) {
-        if let schemas = appConfig.schemaReferences as? [SBBSchemaReference] {
-            // Map the schemas
-            schemas.forEach { self.schemaReferenceMap[$0.identifier] = $0 }
+        // Map the schemas
+        appConfig.schemaReferences?.forEach {
+            self.addMapping(with: $0 as! SBBSchemaReference)
         }
         if let clientData = appConfig.clientData {
             // If there is a clientData object, need to serialize it back into data before decoding it.
             do {
                 let decoder = RSDFactory.shared.createJSONDecoder()
                 let mappingObject = try decoder.decode(SBAActivityMappingObject.self, from: clientData)
+                if let studyDuration = mappingObject.studyDuration {
+                    self.studyDuration = studyDuration
+                }
                 mappingObject.groups?.forEach {
                     self.addMapping(with: $0)
                 }
@@ -118,37 +121,37 @@ open class SBABridgeConfiguration {
                 mappingObject.tasks?.forEach {
                     self.addMapping(with: $0)
                 }
-                if let studyDuration = mappingObject.studyDuration {
-                    self.studyDuration = studyDuration
+                mappingObject.taskToSchemaIdentifierMap?.forEach {
+                    self.addMapping(from: $0.key, to: $0.value)
                 }
-                self.schemaIdentifierMap = mappingObject.schemaIdentifierMap ?? [:]
             } catch let err {
                 debugPrint("Failed to decode the clientData object: \(err)")
             }
         }
     }
     
-    public func activityGroup(with identifier: String) -> SBAActivityGroup? {
-        return activityGroups.first(where: { $0.identifier == identifier })
+    /// Get the activity group with the given identifier.
+    open func activityGroup(with identifier: String) -> SBAActivityGroup? {
+        return activityGroupMap[identifier]
     }
     
     /// Update the mapping by adding the given activity info.
-    public func addMapping(with activityInfo: SBAActivityInfo) {
+    open func addMapping(with activityInfo: SBAActivityInfo) {
         self.activityInfoMap[activityInfo.identifier] = activityInfo
     }
     
     /// Update the mapping by adding the given activity group.
-    public func addMapping(with activityGroup: SBAActivityGroup) {
-        self.activityGroups.append(activityGroup)
+    open func addMapping(with activityGroup: SBAActivityGroup) {
+        self.activityGroupMap[activityGroup.identifier] = activityGroup
     }
     
     /// Update the mapping by adding the given schema reference.
-    public func addMapping(with schemaReference: SBBSchemaReference) {
+    open func addMapping(with schemaReference: SBBSchemaReference) {
         self.schemaReferenceMap[schemaReference.identifier] = schemaReference
     }
     
     /// Update the mapping by adding the given task.
-    public func addMapping(with task: RSDTask) {
+    open func addMapping(with task: RSDTask) {
         if !self.activityInfoMap.contains(where: { $0.value.moduleId?.stringValue == task.identifier })  {
             let activityInfo = SBAActivityInfoObject(identifier: RSDIdentifier(rawValue: task.identifier),
                                                      title: nil,
@@ -161,6 +164,38 @@ open class SBABridgeConfiguration {
             self.addMapping(with: activityInfo)
         }
         self.taskMap[task.identifier] = task
+    }
+    
+    /// Update the mapping from the activity identifier to the matching schema identifier.
+    open func addMapping(from activityIdentifier: String, to schemaIdentifier: String) {
+        self.taskToSchemaIdentifierMap[activityIdentifier] = schemaIdentifier
+    }
+    
+    /// Instantiate a new instance of a task path for the given task info and schedule.
+    open func instantiateTaskPath(for taskInfo: RSDTaskInfo, using schedule: SBBScheduledActivity?) -> RSDTaskPath {
+        let taskPath: RSDTaskPath
+        if let activityReference = schedule?.activity.activityReference {
+            if let taskInfoStep = activityReference as? RSDTaskInfoStep {
+                taskPath = RSDTaskPath(taskInfo: taskInfoStep)
+            }
+            else {
+                let taskInfoStep = RSDTaskInfoStepObject(with: activityReference)
+                taskPath = RSDTaskPath(taskInfo: taskInfoStep)
+            }
+        }
+        else if let task = self.task(for: taskInfo.identifier) {
+            taskPath = RSDTaskPath(task: task)
+        }
+        else if let _ = taskInfo.resourceTransformer {
+            let taskInfoStep = RSDTaskInfoStepObject(with: taskInfo)
+            taskPath = RSDTaskPath(taskInfo: taskInfoStep)
+        }
+        else {
+            assertionFailure("Failed to instantiate the task for this task info.")
+            let task = RSDTaskObject(identifier: taskInfo.identifier, stepNavigator: RSDConditionalStepNavigatorObject(with: []))
+            taskPath = RSDTaskPath(task: task)
+        }
+        return taskPath
     }
     
     /// Return the task transformer for the given activity reference.
@@ -179,7 +214,7 @@ open class SBABridgeConfiguration {
         }
         
         // Finally return a task from the task map (if found).
-        if let task = self.task(for: activityReference) {
+        if let task = self.task(for: activityReference.identifier) {
             return SBAConfigurationTaskTransformer(task: task)
         }
         
@@ -190,33 +225,41 @@ open class SBABridgeConfiguration {
     /// to be able to run active tasks such as "tapping" or "tremor" where the task module is described
     /// in another github repository.
     open func instantiateTaskTransformer(for moduleId: SBAModuleIdentifier) -> RSDTaskTransformer? {
-        return moduleId.taskTransformer()
+        if let transformer = moduleId.taskTransformer() {
+            return transformer
+        }
+        else if let task = self.task(for: moduleId.rawValue) {
+            return SBAConfigurationTaskTransformer(task: task)
+        }
+        else {
+            return nil
+        }
     }
     
-    /// Override this method to return a task for a given activity reference. By default, this method will
-    /// look in its task map for a task with a matching identifier.
-    open func task(for activityReference: SBASingleActivityReference) -> RSDTask? {
+    fileprivate func task(for activityIdentifier: String) -> RSDTask? {
 
         // Look for a mapped task identifier.
-        let storedTask: RSDTask? = {
-            if let task = self.taskMap[activityReference.identifier] {
-                return task
-            }
-            else if let moduleId = activityReference.activityInfo?.moduleId ?? self.schemaIdentifierMap[activityReference.identifier],
-                let task = self.taskMap[moduleId.stringValue] {
-                return task
-            }
-            else {
-                return nil
-            }
-        }()
+        let storedTask = self.taskMap[activityIdentifier]
+        let schemaInfo = self.schemaInfo(for: activityIdentifier)
         
         // Copy if option available.
         if let copyableTask = storedTask as? RSDCopyTask {
-            return copyableTask.copy(with: activityReference.identifier, schemaInfo: activityReference.schemaInfo)
+            return copyableTask.copy(with: activityIdentifier, schemaInfo: schemaInfo)
         } else {
             return storedTask
         }
+    }
+    
+    /// Look for a task info object in the mapping tables for the given activity reference.
+    open func activityInfo(for activityIdentifier: String) -> SBAActivityInfo? {
+        return self.activityInfoMap[activityIdentifier]
+    }
+    
+    /// Get the schema info associated with the given activity identifier. By default, this looks at the
+    /// shared bridge configuration's schema reference map.
+    open func schemaInfo(for activityIdentifier: String) -> RSDSchemaInfo? {
+        let schemaIdentifier = self.taskToSchemaIdentifierMap[activityIdentifier] ?? activityIdentifier
+        return self.schemaReferenceMap[schemaIdentifier]
     }
 }
 
@@ -293,7 +336,7 @@ struct SBAActivityMappingObject : Decodable {
     let groups : [SBAActivityGroupObject]?
     let activityList : [SBAActivityInfoObject]?
     let tasks : [RSDTaskObject]?
-    let schemaIdentifierMap : [String : SBAModuleIdentifier]?
+    let taskToSchemaIdentifierMap : [String : String]?
 }
 
 /// `SBAActivityGroupObject` is a `Decodable` implementation of a `SBAActivityGroup`.

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
@@ -57,7 +57,7 @@ open class SBAScheduleManager: NSObject, RSDDataArchiveManager, RSDTrackingDeleg
     }
     
     /// Pointer to the shared configuration to use.
-    internal var configuration: SBABridgeConfiguration {
+    public var configuration: SBABridgeConfiguration {
         return SBABridgeConfiguration.shared
     }
     

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduledActivityArchive.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduledActivityArchive.swift
@@ -112,9 +112,15 @@ open class SBAScheduledActivityArchive: SBBDataArchive, RSDDataArchive {
     
     /// Close the archive.
     open func completeArchive(with metadata: RSDTaskMetadata) throws {
+        let metadataDictionary = try metadata.rsd_jsonEncodedDictionary()
+        try completeArchive(createdOn: metadata.startDate, with: metadataDictionary)
+    }
+    
+    /// Close the archive with optional metadata from a task result.
+    open func completeArchive(createdOn: Date, with metadata: [String : Any]? = nil) throws {
         
         // Set up the activity metadata.
-        var metadataDictionary = try metadata.rsd_jsonEncodedDictionary()
+        var metadataDictionary: [String : Any] = metadata ?? [:]
         
         // Add metadata values from the schedule.
         if let schedule = self.schedule {
@@ -130,8 +136,8 @@ open class SBAScheduledActivityArchive: SBBDataArchive, RSDDataArchive {
         }
         
         // insert the dictionary.
-        insertDictionary(intoArchive: metadataDictionary, filename: kMetadataFilename, createdOn: metadata.startDate)
-
+        insertDictionary(intoArchive: metadataDictionary, filename: kMetadataFilename, createdOn: createdOn)
+        
         // complete the archive.
         try complete()
     }


### PR DESCRIPTION
Apparently Bridge AppConfig objects cannot have either spaces or dashes in the schema identifier. Therefore, the “study-burst-task” task identifier used by the study burst schedule must be mapped to a schema identifier without dashed. This refactoring is to simplify the mappings required to do this.
