### PR TITLE
Fix “end survey” navigation to go to next section instead.

### DIFF
--- a/BridgeApp/BridgeApp/Research Model/SBBSurveyRule+RSDSurveyRule.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBBSurveyRule+RSDSurveyRule.swift
@@ -115,7 +115,7 @@ extension SBBSurveyRule : RSDComparableSurveyRule {
     }
     
     public var skipToIdentifier: String? {
-        return self.endSurveyValue ? RSDIdentifier.exit.stringValue : self.skipTo
+        return self.endSurveyValue ? RSDIdentifier.nextSection.stringValue : self.skipTo
     }
     
     public var ruleOperator: RSDSurveyRuleOperator? {

--- a/BridgeApp/BridgeAppTests/SurveyNavigationRuleTests.swift
+++ b/BridgeApp/BridgeAppTests/SurveyNavigationRuleTests.swift
@@ -57,7 +57,7 @@ class SurveyNavigationRuleTests: XCTestCase {
         let surveyStep = inputStep
         
         let nextStepIdentifier = surveyStep.nextStepIdentifier(with: nil, conditionalRule: nil, isPeeking: false)
-        XCTAssertEqual(nextStepIdentifier, "exit")
+        XCTAssertEqual(nextStepIdentifier, "nextSection")
     }
     
     // MARK: BooleanConstraints
@@ -98,7 +98,7 @@ class SurveyNavigationRuleTests: XCTestCase {
         taskResult.appendStepHistory(with: stepResult)
         
         let identifierNo = surveyStep.nextStepIdentifier(with: taskResult, conditionalRule: nil, isPeeking: false)
-        XCTAssertEqual(identifierNo, "exit")
+        XCTAssertEqual(identifierNo, "nextSection")
         
         // Set the answer to "skip"
         answerResult.value = nil
@@ -156,7 +156,7 @@ class SurveyNavigationRuleTests: XCTestCase {
         taskResult.appendStepHistory(with: stepResult)
         
         let identifierNo = surveyStep.nextStepIdentifier(with: taskResult, conditionalRule: nil, isPeeking: false)
-        XCTAssertEqual(identifierNo, "exit")
+        XCTAssertEqual(identifierNo, "nextSection")
         
         // Set the answer to "maybe"
         answerResult.value = "maybe"


### PR DESCRIPTION
For Bridge surveys, the rule to end the survey should exit the survey while allowing the next survey to run (in the case of a compound task).