### PR TITLE
Update Carthage BridgeSDK pointer to point to head

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/SageResearch" ~> 1.3.33
-github "Sage-Bionetworks/Bridge-iOS-SDK" "789a1dcd"
+github "Sage-Bionetworks/Bridge-iOS-SDK" "head"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "789a1dcd7b83159ed6434db29369fcde4ecdaa23"
-github "Sage-Bionetworks/SageResearch" "v1.3.33"
+github "Sage-Bionetworks/SageResearch" "v1.3.34"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+if ! command -v carthage > /dev/null; then
+printf 'Carthage is not installed.\n'
+printf 'See https://github.com/Carthage/Carthage for install instructions.\n'
+exit 1
+fi
+
+carthage update --platform iOS --use-submodules --no-use-binaries --no-build


### PR DESCRIPTION
This will setup Carthage on projects that use it to chain BridgeApp and BridgeSDK without BridgeSDK requiring version tags.