### PR TITLE
Fix cached reports

### DIFF
--- a/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
@@ -242,9 +242,9 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
                     do {
                         switch query.queryType {
                         case .mostRecent:
-                            let report: SBBReportData? = try self.participantManager.getLatestCachedData(forReport: query.reportIdentifier)
-                            if report != nil {
-                                self.didFetchReports(for: query, category: category, reports: [report!])
+                            let report: SBBReportData = try self.participantManager.getLatestCachedData(forReport: query.reportIdentifier)
+                            if !report.isEmpty {
+                                self.didFetchReports(for: query, category: category, reports: [report])
                             }
                             else {
                                 self.fetchReport(for: query, category: category, startDate: dayOne, endDate: self.now())
@@ -613,5 +613,12 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
     
     /// Called when all the reports are finished loading. Base class does nothing.
     open func didFinishFetchingReports() {
+    }
+}
+
+extension SBBReportData {
+    
+    var isEmpty: Bool {
+        return data == nil && date == nil
     }
 }

--- a/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
@@ -211,13 +211,18 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
         return []
     }
     
-    /// Reload the data by fetching changes to the reports.
+    /// Reload the data by fetching changes to the data that are used by this manager.
     open func reloadData() {
         loadReports()
     }
     
-    /// State management for whether or not the schedules are reloading.
-    public var isReloading: Bool {
+    /// State management for whether or not the manager is reloading.
+    open var isReloading: Bool {
+        return isReloadingReports
+    }
+    
+    /// State management for whether or not the *reports* specifically are reloading.
+    public final var isReloadingReports: Bool {
         return _reloadingReports.count > 0
     }
     private var _reloadingReports = Set<ReportQuery>()
@@ -225,7 +230,7 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
     /// Load the reports using the `reportQueries()` for this schedule manager.
     public final func loadReports() {
         DispatchQueue.main.async {
-            if self.isReloading { return }
+            if self.isReloadingReports { return }
             let queries = self.reportQueries()
             self._reloadingReports.formUnion(queries)
             

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
@@ -197,7 +197,7 @@ open class SBAScheduleManager: SBAReportManager {
     }
     
     /// State management for whether or not the schedules are reloading.
-    override public var isReloading: Bool {
+    override open var isReloading: Bool {
         return super.isReloading || _isReloadingScheduledActivities
     }
     private var _isReloadingScheduledActivities: Bool = false

--- a/BridgeApp/BridgeAppExample/MainViewController.swift
+++ b/BridgeApp/BridgeAppExample/MainViewController.swift
@@ -104,7 +104,9 @@ class MainViewController: UITableViewController, RSDTaskViewControllerDelegate {
             }
             if let medTrackingResultUnwrapped = medTrackingResult {
                 do {
-                    try scheduleManager.previousClientData[taskController.taskViewModel.taskResult.identifier] = medTrackingResultUnwrapped.dataScore()?.toClientData()
+                    if let dataScore = try medTrackingResultUnwrapped.dataScore() {
+                        self.scheduleManager.previousReport[taskController.taskViewModel.taskResult.identifier] = SBAReport(identifier: taskController.taskViewModel.taskResult.identifier, date: taskController.taskViewModel.taskResult.endDate, json: dataScore)
+                    }
                 } catch {
                     print(error)
                 }
@@ -131,10 +133,10 @@ class MainViewController: UITableViewController, RSDTaskViewControllerDelegate {
 open class ClientDataScheduleManager: SBAScheduleManager {
     
     /// The previous client data for the tasks
-    var previousClientData = [String : SBBJSONValue]()
+    var previousReport = [String : SBAReport]()
     
-    override open func clientData(with activityIdentifier: String) -> SBBJSONValue? {
-        return previousClientData[activityIdentifier]
+    override open func report(with activityIdentifier: String) -> SBAReport? {
+        return previousReport[activityIdentifier]
     }
     
     override open func fetchRequests() -> [FetchRequest] {

--- a/BridgeApp/BridgeAppTests/ScheduleFilteringTests.swift
+++ b/BridgeApp/BridgeAppTests/ScheduleFilteringTests.swift
@@ -306,7 +306,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         SBABridgeConfiguration.shared.addMapping(with: task)
         
         let (taskPath, schedule) = scheduleManager.instantiateTaskViewModel(for: taskInfo)
-        let clientData = scheduleManager.clientData(with: taskInfo.identifier)
+        let clientData = scheduleManager.report(with: taskInfo.identifier)?.clientData
 
         XCTAssertEqual(schedule, expectedSchedule)
         XCTAssertNotNil(clientData)
@@ -349,7 +349,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         SBABridgeConfiguration.shared.addMapping(with: task)
         
         let (taskPath, schedule) = scheduleManager.instantiateTaskViewModel(for: taskInfo)
-        let clientData = scheduleManager.clientData(with: taskInfo.identifier)
+        let clientData = scheduleManager.report(with: taskInfo.identifier)?.clientData
 
         XCTAssertEqual(schedule, expectedSchedule)
         XCTAssertNotNil(clientData)
@@ -400,7 +400,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         SBABridgeConfiguration.shared.addMapping(with: task)
         
         let (taskPath, schedule) = scheduleManager.instantiateTaskViewModel(for: taskInfo, in: group1)
-        let clientData = scheduleManager.clientData(with: taskInfo.identifier)
+        let clientData = scheduleManager.report(with: taskInfo.identifier)?.clientData
 
         XCTAssertEqual(schedule, expectedSchedule)
         XCTAssertNotNil(clientData)
@@ -421,7 +421,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         SBABridgeConfiguration.shared.addMapping(with: task)
         
         let (taskPath, schedule) = scheduleManager.instantiateTaskViewModel(for: taskInfo)
-        let clientData = scheduleManager.clientData(with: taskInfo.identifier)
+        let clientData = scheduleManager.report(with: taskInfo.identifier)?.clientData
 
         XCTAssertNil(schedule)
         XCTAssertNil(clientData)

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Sage-Bionetworks/Bridge-iOS-SDK" "a5412cdb3bb53d5fd9e3027bca69fa14a523256a"
+github "Sage-Bionetworks/Bridge-iOS-SDK" "fb4597b7538e4f493a94272b9a983bc38091a2af"
 github "Sage-Bionetworks/SageResearch" "v1.3.39"


### PR DESCRIPTION
See https://github.com/Sage-Bionetworks/Bridge-iOS-SDK/pull/231

This checks to see if the returned report is empty and if so, follows up with a call to the server to fetch reports from the server.

Additionally, changed the logic for loading reports to allow for simultaneously loading both reports and schedules.