### PR TITLE
Update Cartfile to allow both SageResearch 1.3.39 and 2.0

### DIFF
--- a/BridgeApp/BridgeApp/Study Management/SBASurveyConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBASurveyConfiguration.swift
@@ -81,12 +81,6 @@ open class SBASurveyConfiguration {
         return nil
     }
     
-    // TODO: syoung 03/25/2019 Remove once confirmed that no one is using this.
-    @available(*, deprecated)
-    open func colorTheme(for surveyElement: SBBSurveyElement) -> RSDColorThemeElement? {
-        return nil
-    }
-    
     /// Default implementation is to use the default color theme.
     open func colorMapping(for surveyElement: SBBSurveyElement) -> RSDColorMappingThemeElement? {
         return nil

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Sage-Bionetworks/SageResearch" ~> 1.3.39
+github "Sage-Bionetworks/SageResearch" >= 1.3.39
 github "Sage-Bionetworks/Bridge-iOS-SDK" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "fb4597b7538e4f493a94272b9a983bc38091a2af"
-github "Sage-Bionetworks/SageResearch" "v1.3.39"
+github "Sage-Bionetworks/SageResearch" "v2.0.41"


### PR DESCRIPTION
Use the greater than to indicate that BridgeApp does not *require* higher than 1.3.39, but can pin to 2.0 if another app supports it.

Note: SageResearch has been bumped to 2.0 because the framework organization has changed. This framework has already been updated to the minor version change that introduced the deprecation warnings. I did not remove ResearchRecorders (even though it is deprecated) from the frameworks it links to b/c in 1.3.39, the classes defined in that framework are required by ResearchUI.

