### PR TITLE
Create a custom step for displaying the missed meds

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		FF3A810B22C16D0000CD737D /* SBATimeRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A810A22C16D0000CD737D /* SBATimeRange.swift */; };
 		FF3A810D22C16DE100CD737D /* SBAWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3A810C22C16DE100CD737D /* SBAWarningViewController.swift */; };
 		FF3A810F22C17B9300CD737D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FF3A810E22C17B9300CD737D /* Images.xcassets */; };
+		FF3CC62322D69C8C0037E65B /* SBAMedicationTrackingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3CC62222D69C8C0037E65B /* SBAMedicationTrackingStep.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -276,6 +277,7 @@
 		FF3A810A22C16D0000CD737D /* SBATimeRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATimeRange.swift; sourceTree = "<group>"; };
 		FF3A810C22C16DE100CD737D /* SBAWarningViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAWarningViewController.swift; sourceTree = "<group>"; };
 		FF3A810E22C17B9300CD737D /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		FF3CC62222D69C8C0037E65B /* SBAMedicationTrackingStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBAMedicationTrackingStep.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -622,6 +624,7 @@
 				F8A7FA1322B9B3820053FF74 /* SBADayTimePickerViewController.swift */,
 				FF3A810C22C16DE100CD737D /* SBAWarningViewController.swift */,
 				F8A7FA0B22B814760053FF74 /* BoxedTextField.swift */,
+				FF3CC62222D69C8C0037E65B /* SBAMedicationTrackingStep.swift */,
 			);
 			path = "Medication Tracking";
 			sourceTree = "<group>";
@@ -881,6 +884,7 @@
 				F84794F8207FDEED0024A230 /* SBAFactory.swift in Sources */,
 				60D9611E20BF161300B5CFEB /* SBAProfileItem.swift in Sources */,
 				FF3A810D22C16DE100CD737D /* SBAWarningViewController.swift in Sources */,
+				FF3CC62322D69C8C0037E65B /* SBAMedicationTrackingStep.swift in Sources */,
 				F8479525207FEA9D0024A230 /* SBATrackedSelectionDataSource.swift in Sources */,
 				F89B3DEC20C7155D002EAE2D /* SBAMedicationLoggingStepObject.swift in Sources */,
 				CB18538021064CF90076EFBB /* SBATrackedItemRemindersStepObject.swift in Sources */,

--- a/BridgeApp/BridgeApp/Data Tracking/Medication Tracking/SBAMedicationLoggingStepObject.swift
+++ b/BridgeApp/BridgeApp/Data Tracking/Medication Tracking/SBAMedicationLoggingStepObject.swift
@@ -36,8 +36,11 @@ import Foundation
 /// The medication logging step is used to log information about each item that is being tracked.
 open class SBAMedicationLoggingStepObject : SBATrackedSelectionStepObject {
     
+    /// By default, include all medication dosages and *not* just the ones that
+    /// have not been marked as taken before the current time.
     var shouldIncludeAll: Bool = true
     
+    /// Override to set a value if this is for an active task step.
     open override var title: String? {
         get {
             if shouldIncludeAll {
@@ -50,6 +53,7 @@ open class SBAMedicationLoggingStepObject : SBATrackedSelectionStepObject {
         set { } // ignore setter
     }
     
+    /// Override to set a value if this is for an active task step.
     open override var detail: String? {
         get {
             if shouldIncludeAll {
@@ -121,6 +125,7 @@ open class SBAMedicationLoggingStepObject : SBATrackedSelectionStepObject {
     
     // MARK: RSDNavigationSkipRule
     
+    /// Get the medication timings for the logging step.
     func medicationTimings(at timeOfDay: Date = Date(), with initialResult: SBAMedicationTrackingResult? = nil) -> [MedicationTiming] {
         // If this does not have a medication tracking result then it should be skipped.
         guard let medicationResult = initialResult ?? self.result as? SBAMedicationTrackingResult

--- a/BridgeApp/BridgeApp/Data Tracking/Medication Tracking/SBAMedicationTrackingStep.swift
+++ b/BridgeApp/BridgeApp/Data Tracking/Medication Tracking/SBAMedicationTrackingStep.swift
@@ -1,0 +1,164 @@
+//
+//  SBAMedicationTrackingStep.swift
+//  BridgeApp (iOS)
+//
+//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+public struct SBAMedicationTrackingStep : RSDSubtaskStep {
+    public let stepType: RSDStepType = .medicationTracking
+    public let task: RSDTask
+    
+    public init(mainTask: RSDTask) throws {
+        self.task = try SBAMedicationLoggingTask(mainTask: mainTask)
+    }
+}
+
+struct SBAMedicationLoggingTask : RSDTask, RSDStepNavigator, RSDTrackingTask {
+
+    init(mainTask: RSDTask) throws {
+        guard let navigator = mainTask.stepNavigator as? SBAMedicationTrackingStepNavigator,
+            let loggingStep = navigator.loggingStep as? SBAMedicationLoggingStepObject
+            else {
+                throw RSDValidationError.invalidType("The navigator for the main task is not of the expected type.")
+        }
+        self.identifier = mainTask.identifier
+        self.schemaInfo = mainTask.schemaInfo
+        self.loggingStep = loggingStep
+        self.loggingStep.shouldIncludeAll = false
+    }
+    
+    public let loggingStep: SBAMedicationLoggingStepObject
+    
+    
+    // MARK: `RSDTask`
+    
+    public let identifier: String
+    public let schemaInfo: RSDSchemaInfo?
+    
+    public var stepNavigator: RSDStepNavigator {
+        return self
+    }
+    
+    public func instantiateTaskResult() -> RSDTaskResult {
+        return RSDTaskResultObject(identifier: self.identifier)
+    }
+    
+    public var copyright: String? {
+        return nil
+    }
+    
+    public var asyncActions: [RSDAsyncActionConfiguration]? { return nil }
+    
+    public func validate() throws {
+    }
+    
+    
+    // MARK: RSDStepNavigator
+    
+    func step(with identifier: String) -> RSDStep? {
+        guard identifier == loggingStep.identifier else { return nil }
+        return loggingStep
+    }
+    
+    /// Never exit after answering meds.
+    func shouldExit(after step: RSDStep?, with result: RSDTaskResult) -> Bool {
+        return false
+    }
+    
+    func hasStep(after step: RSDStep?, with result: RSDTaskResult) -> Bool {
+        return _step(after: step) != nil
+    }
+    
+    /// Only one step.
+    func hasStep(before step: RSDStep, with result: RSDTaskResult) -> Bool {
+        return false
+    }
+    
+    /// Return the logging step.
+    func step(after step: RSDStep?, with result: inout RSDTaskResult) -> (step: RSDStep?, direction: RSDStepDirection) {
+        return (_step(after: step), .forward)
+    }
+    
+    func _step(after step: RSDStep?) -> RSDStep? {
+        guard step == nil,
+            loggingStep.medicationTimings().count > 0
+            else {
+                return nil
+        }
+        return loggingStep
+    }
+    
+    /// Only one step.
+    func step(before step: RSDStep, with result: inout RSDTaskResult) -> RSDStep? {
+        return nil
+    }
+    
+    /// Progress is not used.
+    func progress(for step: RSDStep, with result: RSDTaskResult?) -> (current: Int, total: Int, isEstimated: Bool)? {
+        return nil
+    }
+    
+    
+    // MARK: `RSDTrackingTask`
+    
+    /// Build the task data for this task.
+    func taskData(for taskResult: RSDTaskResult) -> RSDTaskData? {
+        guard let loggingResult = taskResult.findResult(for: self.loggingStep) as? SBAMedicationTrackingResult
+            else {
+                return nil
+        }
+        do {
+            guard let dataScore = try loggingResult.dataScore() else {
+                return nil
+            }
+            return SBAReport(identifier: taskResult.identifier, date: taskResult.endDate, json: dataScore)
+        }
+        catch let err {
+            assertionFailure("Failed to get data score from the logging result: \(err)")
+            return nil
+        }
+    }
+    
+    /// Set up the previous client data.
+    func setupTask(with data: RSDTaskData?, for path: RSDTaskPathComponent) {
+        var medsResult = SBAMedicationTrackingResult(identifier: loggingStep.identifier)
+        if let previousClientData = data?.json.toClientData() {
+            try? medsResult.updateSelected(from: previousClientData, with: self.loggingStep.items)
+        }
+        self.loggingStep.result = medsResult
+    }
+    
+    /// Not used. Always return `false`.
+    func shouldSkipStep(_ step: RSDStep) -> (shouldSkip: Bool, stepResult: RSDResult?) {
+        return (false, nil)
+    }
+}

--- a/BridgeApp/BridgeApp/Data Tracking/Medication Tracking/SBAMedicationTrackingStep.swift
+++ b/BridgeApp/BridgeApp/Data Tracking/Medication Tracking/SBAMedicationTrackingStep.swift
@@ -33,17 +33,31 @@
 
 import Foundation
 
+/// The medication tracking step is a step that can be displayed prior to an active task to query
+/// the user about whether or not they have taken their medications that were scheduled for some
+/// point prior to "now" but have not been marked as taken.
+///
+/// Note: Currently, there is no model for marking a participant's response where they have
+/// explicitly said that they have *not* taken the medication.
+///
+/// This step is run as a subtask for two reasons:
+/// 1. Simplifies the upload of changes by using the same model and identifier as the main task.
+/// 2. At some point the UI/UX might change to include additional steps and/or structure.
+///
 public struct SBAMedicationTrackingStep : RSDSubtaskStep {
     public let stepType: RSDStepType = .medicationTracking
     public let task: RSDTask
     
+    /// A logging subtask step is built from the main medication tracking task and is used to
+    /// *only* show the medications that are currently *not* marked as taken at the time when the
+    /// step is displayed.
     public init(mainTask: RSDTask) throws {
         self.task = try SBAMedicationLoggingTask(mainTask: mainTask)
     }
 }
 
 struct SBAMedicationLoggingTask : RSDTask, RSDStepNavigator, RSDTrackingTask {
-
+    
     init(mainTask: RSDTask) throws {
         guard let navigator = mainTask.stepNavigator as? SBAMedicationTrackingStepNavigator,
             let loggingStep = navigator.loggingStep as? SBAMedicationLoggingStepObject
@@ -56,6 +70,7 @@ struct SBAMedicationLoggingTask : RSDTask, RSDStepNavigator, RSDTrackingTask {
         self.loggingStep.shouldIncludeAll = false
     }
     
+    /// The logging step used by this task.
     public let loggingStep: SBAMedicationLoggingStepObject
     
     
@@ -94,6 +109,7 @@ struct SBAMedicationLoggingTask : RSDTask, RSDStepNavigator, RSDTrackingTask {
         return false
     }
     
+    /// Only one step.
     func hasStep(after step: RSDStep?, with result: RSDTaskResult) -> Bool {
         return _step(after: step) != nil
     }

--- a/BridgeApp/BridgeApp/Localization/BridgeApp.strings
+++ b/BridgeApp/BridgeApp/Localization/BridgeApp.strings
@@ -97,10 +97,12 @@
 "MEDICATION_REMOVE_NO" = "No, keep dose";
 "MEDICATION_REMOVE_DOSAGE_CONFIRMATION_MESSAGE" = "Are you sure you want to remove this dose?";
 "MEDICATION_SCHEDULE_SUMMARY" = "%1$@\n%2$@";
-"MEDICATION_RECORD_TODAY_QUESTION" = "Would you like to  record a medication for today?";
+"MEDICATION_RECORD_TODAY_QUESTION" = "Would you like to record a medication for today?";
 "MEDICATION_RECORD_TODAY_YES" = "Record a medication";
 "MEDICATION_RECORD_TODAY_NO" = "Not right now";
 "MEDICATION_RECORD_NONE" = "You have no medications to record right now.";
+"MEDICATION_ACTIVE_TASK_TITLE" = "Did you take your medications today?";
+"MEDICATION_ACTIVE_TASK_DETAIL" = "We noticed that your medications have not been recorded. Did you take them?";
 
 
 "MORNING_PICKER_SECTION_TITLE" = "Morning";

--- a/BridgeApp/BridgeApp/Research Model/SBAFactory.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBAFactory.swift
@@ -120,6 +120,9 @@ extension RSDStepType {
 
     /// Defaults to creating a 'SBATrackedMedicationDetailStepObject'
     public static let medicationDetails: RSDStepType = "medicationDetails"
+    
+    /// Defaults to creating a 'SBAMedicationTrackingStep'
+    public static let medicationTracking: RSDStepType = "medicationTracking"
 }
 
 extension RSDResultType {

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -391,9 +391,9 @@ open class SBABridgeConfiguration {
     /// Get the schema info associated with the given activity identifier. By default, this looks at the
     /// shared bridge configuration's schema reference map.
     open func schemaInfo(for activityIdentifier: String) -> RSDSchemaInfo? {
-        let schemaIdentifier = self.taskToSchemaIdentifierMap[activityIdentifier] ?? activityIdentifier
         var ret: RSDSchemaInfo?
         syncQueue.sync {
+            let schemaIdentifier = self.taskToSchemaIdentifierMap[activityIdentifier] ?? activityIdentifier
             ret = self.schemaReferenceMap[schemaIdentifier]
         }
         return ret

--- a/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
+++ b/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
@@ -464,9 +464,32 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
                                                   date: now.addingNumberOfDays(-1),
                                                   json: ["addedInfo" : "ragu"])]
         
+        // Test assumptions - Part 1
+        // There is some odd condition that only happens when this test is run on the travis
+        // that I can't get to happen on device. Check for that failure here. I suspect that it was
+        // because of a bug where the task to schema mapping was checked outside of the sync queue
+        // but really, that's so very weird since that sync queue shouldn't be necessary when
+        // running a unit test (as oppose to when asyncronously accessing services).
+        // syoung 07/11/2019
+        let reportIdentifier = self.scheduleManager.reportIdentifier(for: task.identifier)
+        XCTAssertEqual(reportIdentifier, mainTaskSchemaIdentifier, "The config is not set up correctly for this test.")
+        let previousReport = self.scheduleManager.previousTaskData(for: RSDIdentifier(rawValue: task.identifier))
+        XCTAssertNotNil(previousReport, "The schedule manager should have a previous report.\n\n now=\(self.scheduleManager.nowValue) \n\n reports=\(self.scheduleManager.reports)")
+
         let taskController = TestTaskController()
         taskController.task = task
         taskController.taskViewModel.dataManager = self.scheduleManager
+        
+        // Test assumptions - Part 2
+        if tracker.setupTask_data == nil {
+            guard let taskViewModel = taskController.taskViewModel else {
+                XCTFail("TaskViewModel is unexpectedly nil.")
+                return
+            }
+
+            XCTAssertNotNil(taskViewModel.task, "Task was previously set. Should not be nil.")
+            XCTAssertNotNil(taskViewModel.dataManager, "DataManager should be set. Should not be nil.")
+        }
         
         // Check that the setup method was called as expected
         XCTAssertNotNil(tracker.setupTask_data)


### PR DESCRIPTION
Really, the whole medication tracking flow including UI/UX and architecture could do with an overhaul. Someday...

This gets the question in there. ¯\_(ツ)_/¯ 

TODO: 

* Update designs to match Sage Design System then update on iOS/Android to match new designs
* Refactor data tracking to allow splitting out the "general purpose" from that which is specific to PD
* Don't try to share the data tracking architecture between triggers, symptoms, medication because there is too much custom UI  and it ends up having to be shoehorned in to match the designs.
* Work with design to come up with better patterns for consistency where permissible.
* Wait for all of this until we can use SwiftUI.  ;)

