### PR TITLE
Fix reports history

### DIFF
--- a/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
@@ -239,13 +239,16 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
         return _reloadingReports.count > 0
     }
     private var _reloadingReports = Set<ReportQuery>()
+    private var _buildingQueries = false
     
     /// Load the reports using the `reportQueries()` for this schedule manager.
     public final func loadReports() {
         DispatchQueue.main.async {
-            if self.isReloadingReports { return }
+            if self.isReloadingReports || self._buildingQueries { return }
+            self._buildingQueries = true
             let queries = self.reportQueries()
             self._reloadingReports.formUnion(queries)
+            self._buildingQueries = false
             
             // If there aren't any reports to fetch then exit early.
             guard queries.count > 0 else {
@@ -497,29 +500,56 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
     }
     
     /// Build the reports to return for this task result.
-    open func buildReports(from taskResult: RSDTaskResult) -> [SBAReport]? {
+    open func buildReports(from topLevelResult: RSDTaskResult) -> [SBAReport]? {
         
         // Recursively build a report for all the schemas in this task path.
         var newReports = [SBAReport]()
-        func appendReports(_ taskResult: RSDTaskResult) {
-            if let schemaInfo = taskResult.schemaInfo ?? self.schemaInfo(for: taskResult.identifier),
-                let schemaIdentifier = schemaInfo.schemaIdentifier,
+        func appendReports(_ taskResult: RSDTaskResult, _ level: Int) {
+            let topResult = (level == 0) ? nil : topLevelResult
+            if let reportIdentifier = self.reportIdentifier(for: taskResult, topLevelResult: topResult),
                 let clientData = buildClientData(from: taskResult) {
-                let date = self.date(for: schemaIdentifier, from: taskResult)
-                let report = SBAReport(reportKey: RSDIdentifier(rawValue: schemaIdentifier),
-                                       date: date,
-                                       clientData: clientData,
-                                       timeZone: TimeZone.current)
-                newReports.append(report)
+                
+                // Look to see if there are multiple levels with the same JSON identifier and
+                // return the merged client data from them.
+                let reportKey = RSDIdentifier(rawValue: reportIdentifier)
+                if let previousReport = newReports.remove(where: { $0.reportKey == reportKey }).first {
+                    if let newJson = clientData as? [String: Any],
+                        let previousJson = previousReport.clientData as? [String: Any] {
+                        let mergedJson = previousJson.merging(newJson) { (previous, _) in previous }
+                        let report = SBAReport(reportKey: reportKey,
+                                               date: previousReport.date,
+                                               clientData: mergedJson as NSDictionary,
+                                               timeZone: previousReport.timeZone)
+                        newReports.append(report)
+                    }
+                    else {
+                        newReports.append(previousReport)
+                    }
+                }
+                else {
+                    let date = self.date(for: reportIdentifier, from: taskResult)
+                    let report = SBAReport(reportKey: reportKey,
+                        date: date,
+                        clientData: clientData,
+                        timeZone: TimeZone.current)
+                    newReports.append(report)
+                }
             }
             taskResult.stepHistory.forEach {
                 guard let subtaskResult = $0 as? RSDTaskResult else { return }
-                appendReports(subtaskResult)
+                appendReports(subtaskResult, level + 1)
             }
         }
-        appendReports(taskResult)
+        appendReports(topLevelResult, 0)
         
         return newReports.count > 0 ? newReports : nil
+    }
+    
+    /// The report identifier to use for the given task result. If the `topLevelResult` is non-nil
+    /// then this task result is a subtask of another result.
+    open func reportIdentifier(for taskResult: RSDTaskResult, topLevelResult: RSDTaskResult?) -> String? {
+        let schemaInfo = taskResult.schemaInfo ?? self.schemaInfo(for: taskResult.identifier)
+        return schemaInfo?.schemaIdentifier
     }
     
     /// The date to use for the report with the given identifier.
@@ -540,7 +570,7 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
     /// - parameters:
     ///     - taskResult: The task result for the task which has just run.
     /// - returns: The client data built for this task result (if any).
-    func buildClientData(from taskResult: RSDTaskResult) -> SBBJSONValue? {
+    open func buildClientData(from taskResult: RSDTaskResult) -> SBBJSONValue? {
         
         // Get the hold data, if any.
         var holdJSON: RSDJSONSerializable?

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduleManager.swift
@@ -176,9 +176,9 @@ open class SBAScheduleManager: SBAReportManager {
     /// The predicate to use for filtering today's activities for those available today. If there is an
     /// `activityGroup` associated with this schedule manager, the fetch request for today's activities will
     /// be built using this predicate and the activity group predicate. Otherwise, only this predicate will
-    /// be used. Default is to return `SBBScheduledActivity.availableTodayPredicate()`.
+    /// be used. Default is to return `SBBScheduledActivity.availableOnPredicate(on: self.now())`.
     open func availablePredicate() -> NSPredicate {
-        return SBBScheduledActivity.availableTodayPredicate()
+        return SBBScheduledActivity.availableOnPredicate(on: self.now())
     }
     
     /// The predicate to use for filtering past activities. By default, this will return all activities where

--- a/BridgeApp/BridgeAppTests/ProfileManagerTests.swift
+++ b/BridgeApp/BridgeAppTests/ProfileManagerTests.swift
@@ -91,10 +91,18 @@ class ProfileManagerTests: XCTestCase {
         // check that it's stored in the appropriate Report as the expected value
         do {
             let reportData = try BridgeSDK.participantManager.getLatestCachedData(forReport: reportItem.sourceKey)
-            guard let data = reportData.data
+            guard let wrappedData = reportData.data
                 else {
                     XCTAssert(false, "Expected reportData.data to exist but it's nil")
                     return
+            }
+            var data: Any!
+            if let dict = wrappedData as? NSDictionary,
+                let clientData = dict[kReportClientDataKey] {
+                    data = clientData
+            }
+            else {
+                data = wrappedData
             }
             var reportValue = data as? RSDJSONSerializable
             if !reportItem.clientDataIsItem {

--- a/BridgeApp/DataTracking/Medication Tracking/SBAMedicationTrackingStepNavigator.swift
+++ b/BridgeApp/DataTracking/Medication Tracking/SBAMedicationTrackingStepNavigator.swift
@@ -623,7 +623,7 @@ public struct SBATimestamp : Codable, RSDScheduleTime {
     internal fileprivate(set) var uuid = UUID().uuidString
     
     private enum CodingKeys : String, CodingKey {
-        case timeOfDay, loggedDate, quantity
+        case timeOfDay, loggedDate, quantity, timeZone
     }
     
     public init(timeOfDay: String? = nil, loggedDate: Date? = nil) {
@@ -651,7 +651,11 @@ public struct SBATimestamp : Codable, RSDScheduleTime {
         self.loggedDate = loggedDate
         self.timeOfDay = validTimeOfDay ? timeOfDay : nil
         
-        if let dateString = try container.decodeIfPresent(String.self, forKey: .loggedDate),
+        if let timeZoneIdentifier = try container.decodeIfPresent(String.self, forKey: .timeZone),
+            let timeZone = TimeZone(identifier: timeZoneIdentifier) {
+            self.timeZone = timeZone
+        }
+        else if let dateString = try container.decodeIfPresent(String.self, forKey: .loggedDate),
             let timeZone = TimeZone(iso8601: dateString) {
             self.timeZone = timeZone
         }
@@ -664,6 +668,7 @@ public struct SBATimestamp : Codable, RSDScheduleTime {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.timeOfDay, forKey: .timeOfDay)
         try container.encode(self.quantity, forKey: .quantity)
+        try container.encode(self.timeZone.identifier, forKey: .timeZone)
         if let loggedDate = self.loggedDate {
             let formatter = encoder.factory.timestampFormatter
             formatter.timeZone = self.timeZone

--- a/BridgeApp/DataTracking/Medication Tracking/SBAMedicationTrackingStepNavigator.swift
+++ b/BridgeApp/DataTracking/Medication Tracking/SBAMedicationTrackingStepNavigator.swift
@@ -668,12 +668,12 @@ public struct SBATimestamp : Codable, RSDScheduleTime {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.timeOfDay, forKey: .timeOfDay)
         try container.encode(self.quantity, forKey: .quantity)
-        try container.encode(self.timeZone.identifier, forKey: .timeZone)
         if let loggedDate = self.loggedDate {
             let formatter = encoder.factory.timestampFormatter
             formatter.timeZone = self.timeZone
             let loggingString = formatter.string(from: loggedDate)
             try container.encode(loggingString, forKey: .loggedDate)
+            try container.encode(self.timeZone.identifier, forKey: .timeZone)
         }
     }
     

--- a/BridgeApp/DataTracking/Model/SBASymptomLoggingStepObject.swift
+++ b/BridgeApp/DataTracking/Model/SBASymptomLoggingStepObject.swift
@@ -438,9 +438,13 @@ public struct SBASymptomResult : Codable, RSDScoringResult {
         let text = try container.decodeIfPresent(String.self, forKey: .text)
         self.text = text ?? identifier
         self.loggedDate = try container.decodeIfPresent(Date.self, forKey: .loggedDate)
+        if let tzIdentifier = try container.decodeIfPresent(String.self, forKey: .timeZone),
+            let timeZone = TimeZone(identifier: tzIdentifier) {
+            self.timeZone = timeZone
+        }
         if let iso8601 = try container.decodeIfPresent(String.self, forKey: .loggedDate),
-            let timezone = TimeZone(iso8601: iso8601) {
-            self.timeZone = timezone
+            let timeZone = TimeZone(iso8601: iso8601) {
+            self.timeZone = timeZone
         }
         else {
             self.timeZone = TimeZone.current
@@ -469,6 +473,7 @@ public struct SBASymptomResult : Codable, RSDScoringResult {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.identifier, forKey: .identifier)
         try container.encode(self.text, forKey: .text)
+        try container.encode(self.timeZone.identifier, forKey: .timeZone)
         if let loggedDate = self.loggedDate {
             let formatter = encoder.factory.timestampFormatter
             formatter.timeZone = self.timeZone

--- a/BridgeApp/DataTracking/Model/SBASymptomLoggingStepObject.swift
+++ b/BridgeApp/DataTracking/Model/SBASymptomLoggingStepObject.swift
@@ -473,12 +473,12 @@ public struct SBASymptomResult : Codable, RSDScoringResult {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.identifier, forKey: .identifier)
         try container.encode(self.text, forKey: .text)
-        try container.encode(self.timeZone.identifier, forKey: .timeZone)
         if let loggedDate = self.loggedDate {
             let formatter = encoder.factory.timestampFormatter
             formatter.timeZone = self.timeZone
             let loggingString = formatter.string(from: loggedDate)
             try container.encode(loggingString, forKey: .loggedDate)
+            try container.encode(self.timeZone.identifier, forKey: .timeZone)
         }
         try container.encodeIfPresent(self.severity, forKey: .severity)
         if let durationString = self.duration?.stringValue {

--- a/BridgeApp/DataTracking/Model/SBATrackedItemsLoggingStepObject.swift
+++ b/BridgeApp/DataTracking/Model/SBATrackedItemsLoggingStepObject.swift
@@ -200,7 +200,7 @@ public struct SBATrackedLoggingCollectionResultObject : RSDCollectionResult, Cod
 public struct SBATrackedLoggingResultObject : RSDCollectionResult, Codable {
 
     private enum CodingKeys : String, CodingKey {
-        case identifier, text, detail, loggedDate, itemIdentifier, timingIdentifier
+        case identifier, text, detail, loggedDate, itemIdentifier, timingIdentifier, timeZone
     }
     
     /// The identifier associated with the task, step, or asynchronous action.
@@ -220,6 +220,9 @@ public struct SBATrackedLoggingResultObject : RSDCollectionResult, Codable {
     
     /// The marker for when the tracked item was logged.
     public var loggedDate: Date?
+    
+    /// The time zone to use for the loggedDate.
+    public let timeZone: TimeZone
     
     /// A String that indicates the type of the result. This is used to decode the result using a `RSDFactory`.
     public var type: RSDResultType = .loggingItem
@@ -243,6 +246,7 @@ public struct SBATrackedLoggingResultObject : RSDCollectionResult, Codable {
         self.text = text
         self.detail = detail
         self.inputResults = []
+        self.timeZone = TimeZone.current
     }
     
     /// Initialize from a `Decoder`. This decoding method will use the `RSDFactory` instance associated
@@ -258,6 +262,12 @@ public struct SBATrackedLoggingResultObject : RSDCollectionResult, Codable {
         self.text = try container.decodeIfPresent(String.self, forKey: .text)
         self.detail = try container.decodeIfPresent(String.self, forKey: .detail)
         self.loggedDate = try container.decodeIfPresent(Date.self, forKey: .loggedDate)
+        if let tzIdentifier = try container.decodeIfPresent(String.self, forKey: .timeZone) {
+            self.timeZone = TimeZone(identifier: tzIdentifier) ?? TimeZone.current
+        }
+        else {
+            self.timeZone = TimeZone.current
+        }
         // TODO: syoung 05/30/2018 Decode the answers.
         self.inputResults = []
     }
@@ -273,6 +283,7 @@ public struct SBATrackedLoggingResultObject : RSDCollectionResult, Codable {
         try container.encodeIfPresent(text, forKey: .text)
         try container.encodeIfPresent(detail, forKey: .detail)
         try container.encodeIfPresent(loggedDate, forKey: .loggedDate)
+        try container.encode(self.timeZone.identifier, forKey: .timeZone)
 
         var anyContainer = encoder.container(keyedBy: AnyCodingKey.self)
         try inputResults.forEach { result in

--- a/BridgeApp/DataTracking/Model/SBATrackedItemsLoggingStepObject.swift
+++ b/BridgeApp/DataTracking/Model/SBATrackedItemsLoggingStepObject.swift
@@ -282,8 +282,13 @@ public struct SBATrackedLoggingResultObject : RSDCollectionResult, Codable {
         try container.encodeIfPresent(timingIdentifier, forKey: .timingIdentifier)
         try container.encodeIfPresent(text, forKey: .text)
         try container.encodeIfPresent(detail, forKey: .detail)
-        try container.encodeIfPresent(loggedDate, forKey: .loggedDate)
-        try container.encode(self.timeZone.identifier, forKey: .timeZone)
+        if let loggedDate = self.loggedDate {
+            let formatter = encoder.factory.timestampFormatter
+            formatter.timeZone = self.timeZone
+            let loggingString = formatter.string(from: loggedDate)
+            try container.encode(loggingString, forKey: .loggedDate)
+            try container.encode(self.timeZone.identifier, forKey: .timeZone)
+        }
 
         var anyContainer = encoder.container(keyedBy: AnyCodingKey.self)
         try inputResults.forEach { result in

--- a/BridgeApp/DataTrackingTests/CodableTrackedDataTests.swift
+++ b/BridgeApp/DataTrackingTests/CodableTrackedDataTests.swift
@@ -784,11 +784,13 @@ class CodableTrackedDataTests: XCTestCase {
                         "daysOfWeek": [2, 4, 6],
                         "timestamps": [{
                                 "timeOfDay": "07:30",
-                                "loggedDate": "2018-02-04T07:45:00.000-08:00"
+                                "loggedDate": "2018-02-04T07:45:00.000-08:00",
+                                "timeZone":"America/Los_Angeles"
                             },
                             {
                                 "timeOfDay": "10:30",
-                                "loggedDate": "2018-02-04T10:30:00.000-08:00"
+                                "loggedDate": "2018-02-04T10:30:00.000-08:00",
+                                "timeZone":"America/Los_Angeles"
                             }
                         ]
                     }]
@@ -799,13 +801,13 @@ class CodableTrackedDataTests: XCTestCase {
                         "dosage": "5 ml",
                         "timestamps": [{
                                 "quantity": 3,
-                                "loggedDate": "2018-02-04T08:00:00.000-08:00"
+                                "loggedDate": "2018-02-04T08:00:00.000-05:00"
                             },
                             {
-                                "loggedDate": "2018-02-04T12:15:00.000-08:00"
+                                "loggedDate": "2018-02-04T12:15:00.000-05:00"
                             },
                             {
-                                "loggedDate": "2018-02-04T20:45:00.000-08:00"
+                                "loggedDate": "2018-02-04T20:45:00.000-05:00"
                             }
                         ]
                     }]
@@ -856,6 +858,19 @@ class CodableTrackedDataTests: XCTestCase {
                     if let timestamp = dosageItem.timestamps?.first {
                         XCTAssertEqual(timestamp.timeOfDay, "08:00")
                         XCTAssertNotNil(timestamp.loggedDate)
+                        XCTAssertEqual(timestamp.timeZone.identifier, "GMT-0800")
+                    }
+                }
+            }
+            else {
+                XCTFail("Failed to decode medA3")
+            }
+            
+            if let med = trackingResult.medications.first(where: { $0.identifier == "medA4" }) {
+                XCTAssertEqual(med.dosageItems?.count, 1)
+                if let dosageItem = med.dosageItems?.first {
+                    if let timestamp = dosageItem.timestamps?.first {
+                        XCTAssertEqual(timestamp.timeZone.identifier, "America/Los_Angeles")
                     }
                 }
             }
@@ -874,6 +889,7 @@ class CodableTrackedDataTests: XCTestCase {
                     if let timestamp = dosageItem.timestamps?.first {
                         XCTAssertNil(timestamp.timeOfDay)
                         XCTAssertNotNil(timestamp.loggedDate)
+                        XCTAssertEqual(timestamp.timeZone.identifier, "GMT-0500")
                     }
                 }
             }
@@ -957,7 +973,6 @@ class CodableTrackedDataTests: XCTestCase {
                 XCTAssertEqual(third.medicationTiming, .preMedication)
             }
             
-            
             let jsonData = try encoder.encode(object.trackedItems)
             let json = try JSONSerialization.jsonObject(with: jsonData, options: [])
             guard let dictionary = json as? [String : Any],
@@ -973,12 +988,14 @@ class CodableTrackedDataTests: XCTestCase {
                 ],
                 [
                     "loggedDate" : "2019-07-29T14:16:24.561-06:00",
+                    "timeZone" : "GMT-0600",
                     "severity" : 3,
                     "text" : "Anger",
                     "identifier" : "Anger"
                 ],
                 [
                     "loggedDate" : "2019-07-29T14:16:14.711-06:00",
+                    "timeZone" : "GMT-0600",
                     "identifier" : "Hallucinations",
                     "duration" : "DURATION_CHOICE_NOW",
                     "text" : "Hallucinations",


### PR DESCRIPTION
This includes fixes for two different issues.

First, if the user was asked additional questions such as medication timing, then the result was wrapped in a task with the top-level identifier set to the active task identifier. This was done to allow merging the answer map for the medication timing with the other answers and works for archiving, but it broke the reports by returning two reports for any task that included the meds question.

Second, I discovered that the bridge reports service always returns the timestamp in GMT timezone so the time zone information was lost if the report was being added from the server vs. added from the initial report (which included the correct timezone). The result was that on startup, a second copy of the report was being added with the time set to 7 hours into the future. Additionally, the time zone abbreviation that is shown to the user on days where they travel was incorrect for these reports, instead of showing "PDT", it showed "GMT-7". So the triggers, meds, symptoms, and active tasks now explicitly set the time zone identifier in the encoding/decoding to get the correct time zone.