### PR TITLE
MP2-254 Decode previous selections from a nested dictionary

### DIFF
--- a/BridgeApp/DataTracking/Model/SBASymptomLoggingStepObject.swift
+++ b/BridgeApp/DataTracking/Model/SBASymptomLoggingStepObject.swift
@@ -295,7 +295,10 @@ open class SBASymptomTableItem : RSDModalStepTableItem {
         set {
             var answerResult = RSDAnswerResultObject(identifier: ResultIdentifier.severity.rawValue, answerType: .integer)
             answerResult.value = newValue?.rawValue
-            _appendResults(answerResult)
+            loggedResult.appendInputResults(with: answerResult)
+            if newValue != nil, loggedResult.loggedDate == nil {
+                loggedResult.loggedDate = Date()
+            }
         }
     }
     
@@ -306,6 +309,9 @@ open class SBASymptomTableItem : RSDModalStepTableItem {
         }
         set {
             loggedResult.loggedDate = newValue
+            if severity == nil {
+                self.severity = .moderate
+            }
         }
     }
     
@@ -318,7 +324,7 @@ open class SBASymptomTableItem : RSDModalStepTableItem {
         set {
             var answerResult = RSDAnswerResultObject(identifier: ResultIdentifier.duration.rawValue, answerType: SBASymptomDurationLevel.answerType)
             answerResult.value = newValue?.answerValue
-            _appendResults(answerResult)
+            loggedResult.appendInputResults(with: answerResult)
         }
     }
     
@@ -333,7 +339,7 @@ open class SBASymptomTableItem : RSDModalStepTableItem {
         set {
             var answerResult = RSDAnswerResultObject(identifier: ResultIdentifier.medicationTiming.rawValue, answerType: .string)
             answerResult.value = newValue?.rawValue
-            _appendResults(answerResult)
+            loggedResult.appendInputResults(with: answerResult)
         }
     }
     
@@ -345,14 +351,7 @@ open class SBASymptomTableItem : RSDModalStepTableItem {
         set {
             var answerResult = RSDAnswerResultObject(identifier: ResultIdentifier.notes.rawValue, answerType: .string)
             answerResult.value = newValue
-            _appendResults(answerResult)
-        }
-    }
-    
-    private func _appendResults(_ answerResult: RSDAnswerResultObject) {
-        loggedResult.appendInputResults(with: answerResult)
-        if loggedResult.loggedDate == nil {
-            loggedResult.loggedDate = Date()
+            loggedResult.appendInputResults(with: answerResult)
         }
     }
     

--- a/BridgeApp/DataTracking/Model/SBATrackedItemsStepNavigator.swift
+++ b/BridgeApp/DataTracking/Model/SBATrackedItemsStepNavigator.swift
@@ -86,7 +86,12 @@ open class SBATrackedItemsStepNavigator : Decodable, RSDStepNavigator, RSDTracki
         didSet {
             // If the previous result is set to a non-nil value then use that as the in-memory result.
             if let clientData = previousClientData {
-                try? _inMemoryResult.updateSelected(from: clientData, with: self.items)
+                do {
+                    try _inMemoryResult.updateSelected(from: clientData, with: self.items)
+                }
+                catch let err {
+                    print("WARNING! Failed to update selected items from the client data: \(err)")
+                }
             }
         }
     }
@@ -112,6 +117,7 @@ open class SBATrackedItemsStepNavigator : Decodable, RSDStepNavigator, RSDTracki
     open func setupTask(with data: RSDTaskData?, for path: RSDTaskPathComponent) {
         self.taskPath = path
         self.previousClientData = data?.json.toClientData()
+        print("previousClientData=\(String(describing: self.previousClientData))")
     }
     
     /// Not used. Always return `false`.


### PR DESCRIPTION
Do not record logged date or symptom results without a severity and decode the
previously selected symptoms from a report that may nest the logging result
with other results.

TODO: Data tracking of symptoms and triggers needs some attention to clean up the UI/UX and the model used to store the tracked items. This fixes the bug but does not address that work.