### PR TITLE
MP2-263 Add data group profile item type

### DIFF
--- a/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
@@ -35,7 +35,7 @@ import Foundation
 import HealthKit
 import BridgeSDK
 
-public protocol SBAProfileItem: Decodable {
+public protocol SBAProfileItem: class, Decodable {
     
     /// profileKey is used to access a specific profile item, and so must be unique across all SBAProfileItems
     /// within an app.
@@ -186,7 +186,7 @@ extension SBAProfileItem {
 /// an editable profile item for each question/answer in the demographic survey. In this scenario, for each of these
 /// items you would set the demographicSchema to the survey identifier, set the source key to the survey identifier
 /// as well, and set the demographicKey to the identifier of the survey question corresponding to the profile item.
-public struct SBAReportProfileItem: SBAProfileItemInternal {
+public final class SBAReportProfileItem: SBAProfileItemInternal {
     private enum CodingKeys: String, CodingKey {
         case profileKey, _sourceKey = "sourceKey", _demographicKey = "demographicKey", demographicSchema,
         _clientDataIsItem = "clientDataIsItem", itemType, _readonly = "readonly", type
@@ -272,6 +272,83 @@ public struct SBAReportProfileItem: SBAProfileItemInternal {
     
 }
 
+/// SBADataGroupProfileItem allows storing and retrieving profile item values to/from a data group.
+///
+/// A common scenario for a study would be to have a demographic survey which is administered once
+/// after the participant signs up and consents. Often (always in e.g. Canada, where required by law),
+/// the app/study design would need some way to allow the participant to change those answers later.
+/// One way to do this is to create an editable profile item for each question/answer in the
+/// demographic survey. In this scenario, for each of these items you would set the demographicSchema
+/// to the survey identifier, set the source key to the survey identifier as well, and set the
+/// demographicKey to the identifier of the survey question corresponding to the profile item.
+public final class SBADataGroupProfileItem: SBAProfileItemInternal {
+    private enum CodingKeys: String, CodingKey {
+        case profileKey, _sourceKey = "sourceKey", _demographicKey = "demographicKey", demographicSchema, itemType, _readonly = "readonly", type, dataGroups
+    }
+
+    fileprivate var _sourceKey: String?
+    
+    fileprivate var _demographicKey: String?
+    
+    fileprivate var _readonly: Bool?
+    
+    /// `profileKey` is used to access a specific profile item, and so must be unique across all
+    /// SBAProfileItems within an app.
+    public var profileKey: String
+    
+    /// `demographicSchema` is an optional schema identifier to mark a profile item as being part of
+    /// the indicated demographic data upload schema.
+    public var demographicSchema: String?
+
+    /// `itemType` specifies what type to store the profileItem's value as. Defaults to String if not
+    /// otherwise specified.
+    public var itemType: RSDFormDataType
+    
+    /// The class type to which to deserialize this profile item.
+    public var type: SBAProfileItemType
+    
+    /// The data groups that are linked to this profile item.
+    public var dataGroups: Set<String>
+    
+    public func storedValue(forKey key: String) -> Any? {
+        guard let currentDataGroups = SBAParticipantManager.shared.studyParticipant?.dataGroups
+            else {
+                return nil
+        }
+        let value = currentDataGroups.intersection(self.dataGroups).joined(separator: ", ")
+        return value
+    }
+    
+    public func setStoredValue(_ newValue: Any?) {
+        guard let participant = SBAParticipantManager.shared.studyParticipant
+            else {
+                print("WARNING! Trying to set the data groups without a participant")
+                return
+        }
+        let currentDataGroups: Set<String> = participant.dataGroups ?? []
+        let newGroups: Set<String> = {
+            if let array = newValue as? [String] {
+                return Set(array)
+            }
+            else if let set = newValue as? Set<String> {
+                return set
+            }
+            else if let string = newValue as? String {
+                let characters = CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ","))
+                let array = string.components(separatedBy: characters).compactMap { $0.isEmpty ? nil : $0
+                }
+                return Set(array)
+            }
+            else {
+                return currentDataGroups
+            }
+        }()
+        let addGroups = self.dataGroups.intersection(newGroups)
+        let updatedGroups = currentDataGroups.subtracting(self.dataGroups).union(addGroups)
+        SBBParticipantManager.default()?.updateDataGroups(withGroups: updatedGroups, completion: nil)
+    }
+}
+
 // The valid keypaths into SBBStudyParticipant for SBAStudyParticipantProfileItems. This will be used to access the
 // values via their keypaths.
 fileprivate struct SBAParticipantKeyPath : RawRepresentable, Codable {
@@ -343,7 +420,7 @@ extension SBBStudyParticipant {
 /// SBAStudyParticipantProfileItem allows storing and retrieving profile item values to/from the SBBStudyParticipant object.
 /// For this type of profile item, the sourceKey (which defaults to the profileKey if not specifically set) is
 /// interpreted as the key path into the SBBStudyParticipant.
-public struct SBAStudyParticipantProfileItem: SBAProfileItemInternal {
+public final class SBAStudyParticipantProfileItem: SBAProfileItemInternal {
     private enum CodingKeys: String, CodingKey {
         case profileKey, _sourceKey = "sourceKey", itemType, _readonly = "readonly", type
     }
@@ -403,7 +480,7 @@ public struct SBAStudyParticipantProfileItem: SBAProfileItemInternal {
 /// If a fallbackKeyPath is set, and the item currently does not have a value specified in the clientData,
 /// the value will be retrieved from the SBBStudyParticipant object at the specified key path. New values
 /// are always set in the clientData and do not affect the value at the fallbackKeyPath.
-public struct SBAStudyParticipantClientDataProfileItem: SBAProfileItemInternal {
+public final class SBAStudyParticipantClientDataProfileItem: SBAProfileItemInternal {
     private enum CodingKeys: String, CodingKey {
         case profileKey, _sourceKey = "sourceKey", _fallbackKeyPath = "fallbackKeyPath", itemType, _readonly = "readonly", type
     }

--- a/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
@@ -281,6 +281,14 @@ public final class SBAReportProfileItem: SBAProfileItemInternal {
 /// demographic survey. In this scenario, for each of these items you would set the demographicSchema
 /// to the survey identifier, set the source key to the survey identifier as well, and set the
 /// demographicKey to the identifier of the survey question corresponding to the profile item.
+///
+/// If you are using this mechanism to change answers to a survey, then use the `SBAReportProfileItem`
+/// for questions that do not effect data groups, and use `SBADataGroupProfileItem` for questions
+/// that can change the data groups. This is also a mechanism for changing the data groups when there
+/// are mutliple surveys that may change those groups.
+///
+/// - seealso: `SBAReportProfileItem`
+///
 public final class SBADataGroupProfileItem: SBAProfileItemInternal {
     private enum CodingKeys: String, CodingKey {
         case profileKey, _sourceKey = "sourceKey", _demographicKey = "demographicKey", demographicSchema, itemType, _readonly = "readonly", type, dataGroups

--- a/BridgeApp/BridgeApp/Profile/SBAProfileItemType.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileItemType.swift
@@ -53,6 +53,9 @@ public struct SBAProfileItemType : RawRepresentable, Codable {
     /// Defaults to creating a `SBAReportProfileItem`.
     public static let report: SBAProfileItemType = "report"
     
+    /// Defaults to creating a `SBADataGroupProfileItem`.
+    public static let dataGroup: SBAProfileItemType = "dataGroup"
+    
     /// List of all the standard types.
     public static func allStandardTypes() -> [SBAProfileItemType] {
         return [.participant, .participantClientData, .report]

--- a/BridgeApp/BridgeApp/Profile/SBAProfileManager.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileManager.swift
@@ -249,7 +249,7 @@ open class SBAProfileManagerObject: SBAScheduleManager, SBAProfileManager, Decod
     /// - parameter value: The new value to set.
     /// - parameter key: The profileKey of the profile item on which to set the new value.
     public func setValue(_ value: Any?, forProfileKey key: String) throws {
-        guard var item = self.itemsMap[key] else {
+        guard let item = self.itemsMap[key] else {
             throw SBAProfileManagerError(errorType: .unknownProfileKey, profileKey: key)
         }
         
@@ -339,9 +339,11 @@ open class SBAProfileManagerObject: SBAScheduleManager, SBAProfileManager, Decod
         
         switch (type) {
         case .report:
-            var item: SBAReportProfileItem = try SBAReportProfileItem(from: decoder)
+            let item: SBAReportProfileItem = try SBAReportProfileItem(from: decoder)
             item.reportManager = self
             return item
+        case .dataGroup:
+            return try SBADataGroupProfileItem(from: decoder)
         case .participant:
             return try SBAStudyParticipantProfileItem(from: decoder)
         case .participantClientData:
@@ -359,7 +361,7 @@ open class SBAProfileManagerObject: SBAScheduleManager, SBAProfileManager, Decod
             return try SBABirthDateProfileItem(from: decoder)
  */
         default:
-            assertionFailure("Attempt to decode profile item of unknown type '\(type.rawValue)'")
+            print("WARNING! Attempt to decode profile item of unknown type '\(type.rawValue)'")
             return nil
         }
     }

--- a/BridgeApp/BridgeApp/Profile/SBAProfileSection.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileSection.swift
@@ -395,14 +395,8 @@ public struct SBAProfileItemProfileTableItem: SBAProfileTableItem, Decodable {
     
     /// The actual profile item for the given profileItemKey.
     public var profileItem: SBAProfileItem? {
-        get {
-            let profileItems = self.profileManager.profileItems()
-            return profileItems[self.profileItemKey]
-        }
-//        set {
-//            var profileItems = self.profileManager.profileItems()
-//            profileItems[self.profileItemKey]!.value = newValue.value
-//       }
+        let profileItems = self.profileManager.profileItems()
+        return profileItems[self.profileItemKey]
     }
     
 /* TODO: emm 2019-02-06 deal with this for mPower 2 2.1

--- a/BridgeApp/BridgeApp/Profile/SBAProfileSection.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileSection.swift
@@ -215,7 +215,7 @@ open class SBAProfileSectionObject: SBAProfileSection, Decodable {
         case .profileView:
             return try SBAProfileViewProfileTableItem(from: decoder)
         default:
-            assertionFailure("Attempt to decode profile table item of unknown type \(type.rawValue)")
+            print("WARNING! Attempt to decode profile table item of unknown type \(type.rawValue)")
             return nil
         }
     }
@@ -301,12 +301,12 @@ public struct SBAProfileItemProfileTableItem: SBAProfileTableItem, Decodable {
     
     /// Detail text to show for the table item.
     public var detail: String? {
-        let type = self.profileItem.itemType
+        guard let type = self.profileItem?.itemType else { return nil }
         let sequenceType = type.defaultAnswerResultType().sequenceType
         let baseType = type.baseType
         if sequenceType == .array &&
             baseType == .string {
-            guard let value = self.profileItem.value as? [String], value.count > 0 else {
+            guard let value = self.profileItem?.value as? [String], value.count > 0 else {
                 return ""
             }
             
@@ -319,7 +319,7 @@ public struct SBAProfileItemProfileTableItem: SBAProfileTableItem, Decodable {
             guard let isOn = self.profileItemValue as? Bool else { return "" }
             return isOn ? Localization.localizedString("SETTINGS_STATE_ON") : Localization.localizedString("SETTINGS_STATE_OFF")
         default:
-            guard let value = self.profileItem.value else { return "" }
+            guard let value = self.profileItem?.value else { return "" }
             return String(describing: value)
         }
     }
@@ -327,10 +327,10 @@ public struct SBAProfileItemProfileTableItem: SBAProfileTableItem, Decodable {
     /// Current profile item value to apply to, and set from, an edit control.
     public var profileItemValue: Any? {
         get {
-            return self.profileItem.value
+            return self.profileItem?.value
         }
         set {
-            self.profileItem.value = newValue
+            self.profileItem?.value = newValue
         }
     }
     
@@ -339,10 +339,10 @@ public struct SBAProfileItemProfileTableItem: SBAProfileTableItem, Decodable {
     private var _isEditable: Bool?
     public var isEditable: Bool? {
         get {
-            return self.profileItem.readonly ? false : self._isEditable ?? true
+            return (self.profileItem?.readonly ?? true) ? false : (self._isEditable ?? true)
         }
         set {
-            guard self.profileItem.readonly == false else { return }
+            guard self.profileItem?.readonly == false else { return }
             self._isEditable = newValue
         }
     }
@@ -389,20 +389,20 @@ public struct SBAProfileItemProfileTableItem: SBAProfileTableItem, Decodable {
     public var _editTaskIdentifier: String?
     public var editTaskIdentifier: String? {
         get {
-            return _editTaskIdentifier ?? self.profileItem.demographicSchema
+            return _editTaskIdentifier ?? self.profileItem?.demographicSchema
         }
     }
     
     /// The actual profile item for the given profileItemKey.
-    public var profileItem: SBAProfileItem {
+    public var profileItem: SBAProfileItem? {
         get {
             let profileItems = self.profileManager.profileItems()
-            return profileItems[self.profileItemKey]!
+            return profileItems[self.profileItemKey]
         }
-        set {
-            var profileItems = self.profileManager.profileItems()
-            profileItems[self.profileItemKey]!.value = newValue.value
-       }
+//        set {
+//            var profileItems = self.profileManager.profileItems()
+//            profileItems[self.profileItemKey]!.value = newValue.value
+//       }
     }
     
 /* TODO: emm 2019-02-06 deal with this for mPower 2 2.1

--- a/BridgeApp/BridgeAppTests/ProfileDataSourceTests.swift
+++ b/BridgeApp/BridgeAppTests/ProfileDataSourceTests.swift
@@ -76,7 +76,7 @@ class ProfileDataSourceTests: XCTestCase {
         
         XCTAssert(piptItem.title == ProfileDataSourceTests.testProfileItemTitle, "Expected profile table item title to be '\(ProfileDataSourceTests.testProfileItemTitle)' but got '\(String(describing:piptItem.title))' instead")
         
-        XCTAssert(piptItem.profileItem.itemType == .base(.boolean), "Expected profile table item's profile item type to be boolean, but it's \(String(describing: piptItem.profileItem.itemType)) instead")
+        XCTAssert(piptItem.profileItem?.itemType == .base(.boolean), "Expected profile table item's profile item type to be boolean, but it's \(String(describing: piptItem.profileItem?.itemType)) instead")
         
         XCTAssert(piptItem.profileItemValue == nil, "Expected default profile item value to be nil but it's \(String(describing: piptItem.profileItemValue))")
         

--- a/BridgeApp/BridgeAppTests/ProfileManagerTests.swift
+++ b/BridgeApp/BridgeAppTests/ProfileManagerTests.swift
@@ -80,7 +80,7 @@ class ProfileManagerTests: XCTestCase {
     func checkProfileItemStorage(profileKey: String) {
         let pm = SBAProfileManagerObject.shared
         let items = pm.profileItems()
-        guard var reportItem = items[profileKey] as? SBAReportProfileItem
+        guard let reportItem = items[profileKey] as? SBAReportProfileItem
             else {
                 XCTAssert(false, "Expected profile items to include a SBAReportProfileItem with the profile key '\(profileKey)' but it doesn't")
                 return
@@ -132,7 +132,7 @@ class ProfileManagerTests: XCTestCase {
     func checkParticipantItemStorage(profileKey: String) {
         let pm = SBAProfileManagerObject.shared
         let items = pm.profileItems()
-        guard var participantItem = items[profileKey] as? SBAStudyParticipantProfileItem
+        guard let participantItem = items[profileKey] as? SBAStudyParticipantProfileItem
             else {
                 XCTAssert(false, "Expected profile items to include a SBAStudyParticipantProfileItem with the profile key '\(profileKey)' but it doesn't")
                 return
@@ -173,7 +173,7 @@ class ProfileManagerTests: XCTestCase {
     func checkParticipantClientDataItemStorage(profileKey: String) {
         let pm = SBAProfileManagerObject.shared
         let items = pm.profileItems()
-        guard var clientDataItem = items[profileKey] as? SBAStudyParticipantClientDataProfileItem
+        guard let clientDataItem = items[profileKey] as? SBAStudyParticipantClientDataProfileItem
             else {
                 XCTAssert(false, "Expected profile items to include a SBAStudyParticipantClientDataProfileItem with the profile key '\(profileKey)' but it doesn't")
                 return
@@ -186,7 +186,7 @@ class ProfileManagerTests: XCTestCase {
                 XCTAssert(false, "Expected profile items to include an item with the source key '\(fallback)' but it doesn't")
                 return
             }
-            guard var participantItem = participantItemTuple.value as? SBAStudyParticipantProfileItem
+            guard let participantItem = participantItemTuple.value as? SBAStudyParticipantProfileItem
                 else {
                     XCTAssert(false, "Expected profile items with the source key '\(fallback)' to be a SBAStudyParticipantProfileItem but instead it's a \(String(describing: type (of:participantItemTuple.value)))")
                     return


### PR DESCRIPTION
As a part of adding the data group profile type, I removed the assertions about unrecoginized decodable types and replaced with a print statement. This is to allow additive profile item types to be reverse-compatible to older versions of an app.

Additionally, I also changed the protocol to use a class instead of a struct. This allows for a more appropriate setter that handles the state of the item. Alternatively, the `value { get set}` pattern could be replaced with a pattern that explicitly calls out how those values are updated. Structs, every time you mutate the struct by setting a property on it, it will copy the struct to a new object. The only reason this was working was because the getter wasn’t ever looking at a cached value and only looks to the backing store.