### PR TITLE
Copy the logging step before displaying to the participant

### DIFF
--- a/BridgeApp/DataTracking/Medication Tracking/SBAMedicationTrackingStep.swift
+++ b/BridgeApp/DataTracking/Medication Tracking/SBAMedicationTrackingStep.swift
@@ -66,7 +66,7 @@ struct SBAMedicationLoggingTask : RSDTask, RSDStepNavigator, RSDTrackingTask {
         }
         self.identifier = mainTask.identifier
         self.schemaInfo = mainTask.schemaInfo
-        self.loggingStep = loggingStep
+        self.loggingStep = loggingStep.copy(with: loggingStep.identifier)
         self.loggingStep.shouldIncludeAll = false
     }
     


### PR DESCRIPTION
When displayed as part of an active task, the logging step is mutated to change the title and text that is displayed to the user. Because of this, when shown from the meds button, it was showing the wrong language. This is a class and *not* a struct, therefore it needs to be copied explicitly. Ooops.