### PR TITLE
Fix report fetch for groupedByDay to use dateOnly method

### DIFF
--- a/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAReportManager.swift
@@ -681,7 +681,12 @@ open class SBAReportManager: SBAArchiveManager, RSDDataStorageManager {
         case .groupByDay:
             // The report date on groupByDay reports will be at the start of a day, and the Bridge endpoint for retrieving reports appears
             // to be non-inclusive for the startDate parameter, so we need to fudge it a bit to make sure we include the report for startDate.
-            self.participantManager.getReport(query.reportIdentifier, fromTimestamp: startDate.startOfDay().addingTimeInterval(-1.0), toTimestamp: endDate.addingNumberOfDays(1).startOfDay()) { [weak self] (obj, error) in
+            self.participantManager.getReport(query.reportIdentifier, fromDate: startDate.startOfDay().addingTimeInterval(-1.0).dateOnly(), toDate: endDate.addingNumberOfDays(1).startOfDay().dateOnly()) { [weak self] (obj, error) in
+                
+                if query.reportIdentifier == "Medication" {
+                    print(category)
+                }
+                
                 self?.didFetchReports(for: query, category: category, reports: obj as? [SBBReportData], error: error)
             }
             


### PR DESCRIPTION
*sigh*

So... didn't realize that there was a difference in how the cached reports are handled between timestamp and groupByDay and the Medication history wasn't getting populated correctly.

All the other reports only use "most recent" so they correctly get the most recent report from cache.