### PR TITLE
Fixed unsorted report set bug

### DIFF
--- a/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
@@ -236,7 +236,8 @@ public final class SBAReportProfileItem: SBAProfileItemInternal {
     
     public func storedValue(forKey key: String) -> Any? {
         guard let reportManager = self.reportManager,
-                let clientData = reportManager.reports.first(where: { $0.reportKey == RSDIdentifier(rawValue: key) })?.clientData
+            // This is the most recent report's client data.
+            let clientData = reportManager.report(with: RSDIdentifier(rawValue: key).rawValue)?.clientData
             else {
                 return nil
         }


### PR DESCRIPTION
SBAReportProfileItem storedValue function was returning unpredictable results, because it was accessing an unsorted set directly to get its value.  This is fine for singletons, but for groupByDay and timestamp, it was all over the place.  I switched it over to use the report manager's most recent report with identifier function so that it now displays the current report client data.

CC @Erin-Mounts @syoung-smallwisdom 