### PR TITLE
Migrate to SageResearch v3.1

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -38,8 +38,6 @@
 		F83B450F20324A33002825AE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F83B450D20324A33002825AE /* LaunchScreen.storyboard */; };
 		F84794F8207FDEED0024A230 /* SBAFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84794F7207FDEED0024A230 /* SBAFactory.swift */; };
 		F86AFC2822AED6140070E347 /* BridgeApp.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = F86AFC2722AED6140070E347 /* BridgeApp.stringsdict */; };
-		F87D2AC622780599007CA2B5 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2AC522780599007CA2B5 /* BridgeSDK.framework */; };
-		F87D2AC822780599007CA2B5 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2AC722780599007CA2B5 /* Research.framework */; };
 		F87D2ACE227805B1007CA2B5 /* BridgeSDK_Test.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2ACD227805B1007CA2B5 /* BridgeSDK_Test.framework */; };
 		F87D2AD0227805B1007CA2B5 /* Research_UnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2ACF227805B1007CA2B5 /* Research_UnitTest.framework */; };
 		F87D696A2037956B00409087 /* SBAActivityReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87D69692037956B00409087 /* SBAActivityReference.swift */; };
@@ -76,6 +74,12 @@
 		FF196A99242C29CA008BD7EA /* Symptoms.json in Resources */ = {isa = PBXBuildFile; fileRef = FF196A96242C29C9008BD7EA /* Symptoms.json */; };
 		FF196A9A242C29CA008BD7EA /* Triggers.json in Resources */ = {isa = PBXBuildFile; fileRef = FF196A97242C29CA008BD7EA /* Triggers.json */; };
 		FF196A9B242C29CA008BD7EA /* Medication.json in Resources */ = {isa = PBXBuildFile; fileRef = FF196A98242C29CA008BD7EA /* Medication.json */; };
+		FF29AAA624492FAD00C39E02 /* BridgeSDK_Test.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF29AAA424492F8B00C39E02 /* BridgeSDK_Test.framework */; };
+		FF29AAA724492FAD00C39E02 /* BridgeSDK_Test.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FF29AAA424492F8B00C39E02 /* BridgeSDK_Test.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FF29AAA924492FAF00C39E02 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2AC522780599007CA2B5 /* BridgeSDK.framework */; };
+		FF29AAAA24492FAF00C39E02 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2AC522780599007CA2B5 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FF29AAAB24492FB100C39E02 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2AC722780599007CA2B5 /* Research.framework */; };
+		FF29AAAC24492FB100C39E02 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2AC722780599007CA2B5 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FF3A810F22C17B9300CD737D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FF3A810E22C17B9300CD737D /* Images.xcassets */; };
 		FF63D5002303731B006C7BD3 /* SBALearnItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63D4FE2303731A006C7BD3 /* SBALearnItem.swift */; };
 		FF63D5012303731B006C7BD3 /* SBALearnInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63D4FF2303731A006C7BD3 /* SBALearnInfo.swift */; };
@@ -215,6 +219,19 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FF29AAA824492FAD00C39E02 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				FF29AAAA24492FAF00C39E02 /* BridgeSDK.framework in Embed Frameworks */,
+				FF29AAAC24492FB100C39E02 /* Research.framework in Embed Frameworks */,
+				FF29AAA724492FAD00C39E02 /* BridgeSDK_Test.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -334,6 +351,7 @@
 		FF196A96242C29C9008BD7EA /* Symptoms.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Symptoms.json; sourceTree = "<group>"; };
 		FF196A97242C29CA008BD7EA /* Triggers.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Triggers.json; sourceTree = "<group>"; };
 		FF196A98242C29CA008BD7EA /* Medication.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Medication.json; sourceTree = "<group>"; };
+		FF29AAA424492F8B00C39E02 /* BridgeSDK_Test.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK_Test.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FF3A810A22C16D0000CD737D /* SBATimeRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBATimeRange.swift; sourceTree = "<group>"; };
 		FF3A810C22C16DE100CD737D /* SBAWarningViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBAWarningViewController.swift; sourceTree = "<group>"; };
 		FF3A810E22C17B9300CD737D /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -366,8 +384,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F87D2AC622780599007CA2B5 /* BridgeSDK.framework in Frameworks */,
-				F87D2AC822780599007CA2B5 /* Research.framework in Frameworks */,
+				FF29AAA624492FAD00C39E02 /* BridgeSDK_Test.framework in Frameworks */,
+				FF29AAAB24492FB100C39E02 /* Research.framework in Frameworks */,
+				FF29AAA924492FAF00C39E02 /* BridgeSDK.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -545,6 +564,7 @@
 		F83B44C02032470A002825AE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FF29AAA424492F8B00C39E02 /* BridgeSDK_Test.framework */,
 				FF9D79D1230C7DEF005CFB37 /* BridgeSDK_Test.framework */,
 				FF9D79D3230C7DEF005CFB37 /* Research_UnitTest.framework */,
 				FF9D79CE230C7C30005CFB37 /* BridgeSDK.framework */,
@@ -875,6 +895,7 @@
 				F83B44A12032467D002825AE /* Frameworks */,
 				F83B44A22032467D002825AE /* Headers */,
 				F83B44A32032467D002825AE /* Resources */,
+				FF29AAA824492FAD00C39E02 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/BridgeApp/BridgeApp/Research Model/SBBSurveyElement+RSDStep.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBBSurveyElement+RSDStep.swift
@@ -62,7 +62,7 @@ extension SBBSurveyElement {
 
 extension SBBSurveyElement : RSDUIStep {
     
-    public var text: String? {
+    public var subtitle: String? {
         return self.prompt.sba_parseNewLine()
     }
     

--- a/BridgeApp/DataTrackingTests/ArchivableTrackingTests.swift
+++ b/BridgeApp/DataTrackingTests/ArchivableTrackingTests.swift
@@ -235,8 +235,8 @@ class ArchivableTrackingTests: XCTestCase {
                     if let dosageItems = item["dosageItems"] as? [[String : Any]],
                         let dosageItem = dosageItems.first {
                         XCTAssertEqual(dosageItem["dosage"] as? String, "1 ml")
-                        if let daysOfWeek = dosageItem["daysOfWeek"] as? [Int] {
-                            XCTAssertEqual(Set(daysOfWeek), [6,4,2])
+                        if let daysOfWeek = dosageItem["daysOfWeek"] as? [String] {
+                            XCTAssertEqual(Set(daysOfWeek), ["Friday","Wednesday","Monday"])
                         }
                         else {
                             XCTFail("Failed to encode `daysOfWeek`.")

--- a/BridgeApp/DataTrackingTests/CodableTrackedDataTests.swift
+++ b/BridgeApp/DataTrackingTests/CodableTrackedDataTests.swift
@@ -243,7 +243,7 @@ class CodableTrackedDataTests: XCTestCase {
             "identifier": "ibuprofen",
             "dosageItems" : [ {
                                 "dosage": "10/100 mg",
-                                "daysOfWeek": [1,3,5],
+                                "daysOfWeek": ["Sunday","Tuesday","Thursday"],
                                 "timestamps": [{ "timeOfDay" : "08:00" }]
                               }
                             ]
@@ -279,8 +279,8 @@ class CodableTrackedDataTests: XCTestCase {
                 XCTAssertEqual(items.count, 1)
                 if let dosageDictionary = items.first {
                     XCTAssertEqual(dosageDictionary["dosage"] as? String, "10/100 mg")
-                    if let daysOfWeek = dosageDictionary["daysOfWeek"] as? [Int] {
-                        XCTAssertEqual(Set(daysOfWeek), [1,3,5])
+                    if let daysOfWeek = dosageDictionary["daysOfWeek"] as? [String] {
+                        XCTAssertEqual(Set(daysOfWeek), ["Sunday","Tuesday","Thursday"])
                     }
                     else {
                         XCTFail("Failed to encode the days of week")
@@ -462,7 +462,7 @@ class CodableTrackedDataTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.title, "Hello World!")
-            XCTAssertEqual(object.text, "Some text.")
+            XCTAssertEqual(object.subtitle, "Some text.")
             XCTAssertEqual(object.detail, "This is a test.")
             XCTAssertEqual(object.footnote, "This is a footnote.")
             XCTAssertEqual((object.imageTheme as? RSDFetchableImageThemeElementObject)?.imageName, "before")

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Sage-Bionetworks/SageResearch" ~> 3.0
+github "Sage-Bionetworks/SageResearch" ~> 3.1
 github "Sage-Bionetworks/Bridge-iOS-SDK" ~> 4.2.72

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "v4.2.75"
-github "Sage-Bionetworks/SageResearch" "v3.0.85"
+github "Sage-Bionetworks/SageResearch" "v3.1.86"


### PR DESCRIPTION
I fixed errors but did *not* change any of the deprecation warnings.

I figure, we may decide to deprecate support for the SBBSurvey v1 stuff and replace it with the Kotlin-native / SageResearch serialization strategy instead. Decided to punt that down the road a bit. :)