### PR TITLE
Update to SageResearch 3.7

### DIFF
--- a/BridgeApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BridgeApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "JsonModel",
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
-          "branch": "master",
-          "revision": "700316457641607b87e4e52c82c1950b432826ee",
-          "version": null
+          "branch": null,
+          "revision": "9237442bd2ea208554e01041feaa2d4a065d61a4",
+          "version": "1.0.2"
         }
       }
     ]

--- a/BridgeApp/BridgeApp/Study Management/SBAArchiveManager.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAArchiveManager.swift
@@ -104,7 +104,7 @@ open class SBAArchiveManager : NSObject, RSDDataArchiveManager {
         
         // Look for a schema info associated with this portion of the task result. If not found, then
         // return the current archive.
-        let schema = taskResult.schemaInfo ?? self.schemaInfo(for: taskResult.identifier)
+        let schema = (taskResult as? RSDTaskRunResult)?.schemaInfo ?? self.schemaInfo(for: taskResult.identifier)
         guard (currentArchive == nil) || (schema != nil) else {
             return currentArchive
         }

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduledActivityArchive.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduledActivityArchive.swift
@@ -163,7 +163,7 @@ open class SBAScheduledActivityArchive: SBBDataArchive, RSDDataArchive {
         // needing to release, pushing a work-around while I continue to investigate.
         if !self.usesV1LegacySchema, self.answersDictionary == nil, let taskResult = self.taskResult {
             let builder = RSDDefaultScoreBuilder()
-            let answers = builder.getScoringData(from: taskResult) as? [String : Any] ?? [String : Any]()
+            let answers = builder.getScoringData(from: taskResult) as? [String : JsonSerializable] ?? [String : Any]()
             self.insertAnswersDictionary(answers)
         }
         

--- a/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
+++ b/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
@@ -224,7 +224,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
     
     func testBuildReports_CompoundTask() {
         let taskPath = runCompoundTask()
-        let topResult = taskPath.taskResult
+        let topResult = taskPath.taskResult as! RSDTaskRunResult
         guard let reports = self.scheduleManager.buildReports(from: taskPath.taskResult)
             else {
                 XCTFail("Failed to build the reports for this task result")
@@ -295,6 +295,8 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
         
         XCTAssertEqual(reports.count, 3)
         
+        let topResult = taskPath.taskResult as! RSDTaskRunResult
+        
         if let report = reports.first(where: { $0.reportKey == mainTaskSchemaIdentifier }) {
             XCTAssertEqual(report.date, mainResult?.endDate)
             if let dictionary = report.clientData as? NSDictionary {
@@ -305,7 +307,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
                                "stepY" : "stepY moo"],
                     "step3": [ "stepX" : "stepX moo",
                                "stepY" : "stepY moo"],
-                    "taskRunUUID" : taskPath.taskResult.taskRunUUID.uuidString
+                    "taskRunUUID" : topResult.taskRunUUID.uuidString
                 ]
                 XCTAssertEqual(dictionary as NSDictionary, expectedDictionary)
             }
@@ -324,7 +326,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
                     "stepA" : 0,
                     "stepB" : 1,
                     "stepC" : 2,
-                    "taskRunUUID" : taskPath.taskResult.taskRunUUID.uuidString
+                    "taskRunUUID" : topResult.taskRunUUID.uuidString
                 ]
                 XCTAssertEqual(dictionary as NSDictionary, expectedDictionary)
             }
@@ -360,6 +362,8 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
         
         XCTAssertEqual(reports.count, 1)
         
+        let topResult = taskPath.taskResult as! RSDTaskRunResult
+        
         if let report = reports.first(where: { $0.reportKey == mainTaskSchemaIdentifier }) {
             if let dictionary = report.clientData as? NSDictionary {
                 let expectedDictionary : NSDictionary = [
@@ -373,7 +377,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
                     ],
                     "foo" : 3,
                     "baroo" : 5,
-                    "taskRunUUID" : taskPath.taskResult.taskRunUUID.uuidString
+                    "taskRunUUID" : topResult.taskRunUUID.uuidString
                 ]
                 XCTAssertEqual(dictionary as NSDictionary, expectedDictionary)
             }

--- a/BridgeApp/DataTrackingTests/ArchivableTrackingTests.swift
+++ b/BridgeApp/DataTrackingTests/ArchivableTrackingTests.swift
@@ -34,6 +34,7 @@
 import XCTest
 @testable import BridgeApp
 @testable import DataTracking
+import JsonModel
 
 class ArchivableTrackingTests: XCTestCase {
     
@@ -62,7 +63,7 @@ class ArchivableTrackingTests: XCTestCase {
         do {
             let clientData = try result.dataScore()
             XCTAssertNotNil(clientData)
-            if let clientData = clientData as? [String : Any] {
+            if let clientData = clientData as? [String : JsonSerializable] {
                 XCTAssertEqual(clientData["identifier"] as? String, identifier)
                 if let items = clientData["items"] as? [[String : Any]] {
                     XCTAssertEqual(items.count, 2)
@@ -226,7 +227,7 @@ class ArchivableTrackingTests: XCTestCase {
         result.medications = [medA3, medC3]
         
         do {
-            let clientData = try result.dataScore() as? [String : Any]
+            let clientData = try result.dataScore() as? [String : JsonSerializable]
             XCTAssertNotNil(clientData)
             if let items = clientData?["items"] as? [[String : Any]] {
                 XCTAssertEqual(items.count, 2)

--- a/BridgeApp/DataTrackingTests/MedicationLoggingDataSourceTests.swift
+++ b/BridgeApp/DataTrackingTests/MedicationLoggingDataSourceTests.swift
@@ -34,6 +34,7 @@
 import XCTest
 @testable import BridgeApp
 @testable import DataTracking
+import ResearchUI
 
 class MedicationLoggingDataSourceTests: XCTestCase {
 
@@ -41,6 +42,7 @@ class MedicationLoggingDataSourceTests: XCTestCase {
         super.setUp()
 
         NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+        LocalizationBundle.registerDefaultBundlesIfNeeded()
     }
 
     override func tearDown() {

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Sage-Bionetworks/SageResearch" ~> 3.2
+github "Sage-Bionetworks/SageResearch" ~> 3.7
 github "Sage-Bionetworks/Bridge-iOS-SDK" ~> 4.2.72

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "v4.2.75"
-github "Sage-Bionetworks/SageResearch" "v3.3.90"
+github "Sage-Bionetworks/SageResearch" "v3.7.96"


### PR DESCRIPTION
Note: This does *not* fix all the deprecation warnings. Doing so is a longer conversation about whether or not we want to continue supporting legacy v1 surveys.
