### PR TITLE
Fix deprecation warnings

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		FF9D79D4230C7DEF005CFB37 /* Research_UnitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF9D79D3230C7DEF005CFB37 /* Research_UnitTest.framework */; };
 		FFA071872357914900EA371F /* SBAMedicationReminderTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA071862357914900EA371F /* SBAMedicationReminderTask.swift */; };
 		FFA07189235801EE00EA371F /* SBAMedicationFollowupTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA07188235801EE00EA371F /* SBAMedicationFollowupTask.swift */; };
+		FFF2968F24EF2C52000E36FB /* TextConstraintWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF2968E24EF2C52000E36FB /* TextConstraintWrapper.swift */; };
+		FFF2969324F454B9000E36FB /* SBAProfileDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF2969224F454B9000E36FB /* SBAProfileDataType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -364,6 +366,8 @@
 		FF9D79D5230C7E8D005CFB37 /* DataTrackingTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DataTrackingTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		FFA071862357914900EA371F /* SBAMedicationReminderTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBAMedicationReminderTask.swift; sourceTree = "<group>"; };
 		FFA07188235801EE00EA371F /* SBAMedicationFollowupTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBAMedicationFollowupTask.swift; sourceTree = "<group>"; };
+		FFF2968E24EF2C52000E36FB /* TextConstraintWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextConstraintWrapper.swift; sourceTree = "<group>"; };
+		FFF2969224F454B9000E36FB /* SBAProfileDataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SBAProfileDataType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -441,6 +445,7 @@
 				60D9611620BF161200B5CFEB /* SBAProfileItem.swift */,
 				60D9611720BF161200B5CFEB /* SBAProfileDataSource.swift */,
 				60D9611A20BF161200B5CFEB /* SBAProfileManager.swift */,
+				FFF2969224F454B9000E36FB /* SBAProfileDataType.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -673,6 +678,7 @@
 				F899D0E420D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift */,
 				FF9D799E230C7555005CFB37 /* SBBJSONValue+RSDJSONSerializable.swift */,
 				FF196A7A242AB452008BD7EA /* ScheduledAssessment.swift */,
+				FFF2968E24EF2C52000E36FB /* TextConstraintWrapper.swift */,
 			);
 			path = "Research Model";
 			sourceTree = "<group>";
@@ -1144,6 +1150,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F80F175F2033980300352C3E /* SBBSurveyRule+RSDSurveyRule.swift in Sources */,
+				FFF2968F24EF2C52000E36FB /* TextConstraintWrapper.swift in Sources */,
 				60E84E5C20D306A9000DDCB1 /* SBAProfileItemType.swift in Sources */,
 				F82B1AB12036410C00FEA16D /* SBABridgeConfiguration.swift in Sources */,
 				F87D696A2037956B00409087 /* SBAActivityReference.swift in Sources */,
@@ -1176,6 +1183,7 @@
 				F899D0E520D03C9A0039FE8A /* SBBScheduledActivity+ResearchModel.swift in Sources */,
 				F886FD1320351E1E00EF2248 /* SBBActivity+RSDTaskInfo.swift in Sources */,
 				6090544821308CF7002D1895 /* SBAProfileOnSelectedAction.swift in Sources */,
+				FFF2969324F454B9000E36FB /* SBAProfileDataType.swift in Sources */,
 				F8C7D4162092CF36007490BC /* UIColor+BridgeKeyNames.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BridgeApp/BridgeApp/Info-iOS.plist
+++ b/BridgeApp/BridgeApp/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2</string>
+	<string>4.3</string>
 	<key>CFBundleVersion</key>
 	<string>26</string>
 	<key>NSPrincipalClass</key>

--- a/BridgeApp/BridgeApp/Localization/BridgeApp.strings
+++ b/BridgeApp/BridgeApp/Localization/BridgeApp.strings
@@ -141,3 +141,9 @@
 "SYMPTOM_SEVERITY_MILD" = "Mild";
 "SYMPTOM_SEVERITY_MODERATE" = "Moderate";
 "SYMPTOM_SEVERITY_SEVERE" = "Severe";
+
+/* String length */
+"INVALID_TEXT_LENGTH_MIN_%@" = "Must be at least %@ characters.";
+"INVALID_TEXT_LENGTH_MAX_%@" = "Must be less than or equal to %@ characters.";
+"INVALID_TEXT_LENGTH_MIN_MAX" = "Must be at least %1$@ characters and less than or equal to %2$@ characters.";
+"INVALID_TEXT_LENGTH_SAME" = "Must be %@ characters.";

--- a/BridgeApp/BridgeApp/Profile/SBAProfileDataType.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileDataType.swift
@@ -1,0 +1,332 @@
+//
+//  SBAProfileDataType.swift
+//  BridgeApp (iOS)
+//
+//  Created by Shannon Young on 8/24/20.
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+
+import Foundation
+
+import JsonModel
+
+public enum SBAProfileDataType {
+    
+    /// Base data types are basic types that can be defined with only a base type.
+    case base(BaseType)
+    
+    /// Collection data types are some kind of a collection with a base type.
+    case collection(CollectionType, BaseType)
+    
+    /// A date that includes encoding information for the portion of the date/time that is
+    /// represented by this data type.
+    case dateRange(DateRangeType)
+    
+    /// A measurement is a human-data measurement. The measurement range indicates the expected size
+    /// of the human being measured. In US English units, this is required to determine the expected
+    /// localization for the measurement.
+    ///
+    /// For example, an infant weight would be in lb/oz whereas an adult weight would be in lb.
+    /// Default range is for an adult.
+    case measurement(MeasurementType, MeasurementRange)
+    
+    /// A postal code is a custom input field that only stores a part of the participant's postal
+    /// code (zipcode). This is to protect the participant's privacy. Typically, this will mean
+    /// only storing the first 3 characters of the postal code. The base type for a postal code is
+    /// always a string.
+    case postalCode
+    
+    /// A "detail" form data type is a data type that represents an input field where the data entry uses a
+    /// detail that displays information using one or more input fields. The default base type is `.codable`.
+    case detail(BaseType)
+    
+    /// Custom data types are undefined in the base SDK.
+    case custom(String, BaseType)
+    
+    /// The base type of the form input field. This is used to indicate what the type is of the
+    /// value being prompted and will affect the choice of allowed formatters.
+    public enum BaseType: String, CaseIterable {
+
+        /// The Boolean question type asks the participant to enter Yes or No (or the appropriate equivalents).
+        case boolean
+        
+        /// In a date question, the participant can enter a date, time, or combination of the two. A date data
+        /// type can map to a `RSDDateRange` to box the allowed values.
+        case date
+        
+        /// The decimal question type asks the participant to enter a decimal number. A decimal data type can
+        /// map to a `RSDNumberRange` to box the allowed values.
+        case decimal
+        
+        /// In a duration question, the participant can enter a time span such as "8 hours, 5 minutes"
+        /// or "3 minutes, 15 seconds".
+        case duration
+        
+        /// The fraction question type asks the participant to enter a fractional number. A fractional data type
+        /// can map to a `RSDNumberRange` to box the allowed values.
+        case fraction
+        
+        /// The integer question type asks the participant to enter an integer number. An integer data type can
+        /// map to a `RSDNumberRange` to box the allowed values, but will store the value as an `Int`.
+        case integer
+        
+        /// In a string question, the participant can enter text.
+        case string
+        
+        /// In a year question, the participant can enter a year when an event occured. A year data type can map
+        /// to an `RSDDateRange` or `RSDNumberRange` to box the allowed values.
+        case year
+        
+        /// A `Codable` object. This is an object that can be represented using a JSON or XML dictionary.
+        case codable
+    }
+    
+    /// The collection type for the input field. The supported types are for choice-style questions or
+    /// multiple component questions where the user selected from one or more fields to build a single
+    /// answer result.
+    public enum CollectionType: String, CaseIterable {
+        
+        /// In a multiple choice question, the participant can pick one or more options.
+        case multipleChoice
+        
+        /// In a single choice question, the participant can pick one item from a list of options.
+        case singleChoice
+        
+        /// In a multiple component question, the participant can pick one choice from each component
+        /// or enter a formatted text string such as a phone number or blood pressure.
+        case multipleComponent
+    }
+    
+    /// A measurement type is a human-data measurement such as height or weight.
+    public enum MeasurementType: String, CaseIterable {
+        
+        /// A measurement of height.
+        case height
+        
+        /// A measurement of weight.
+        case weight
+        
+        /// A measurement of blood pressure.
+        case bloodPressure
+    }
+    
+    /// The measurement range is used to determine units that are appropriate to the
+    /// size of the person.
+    public enum MeasurementRange: String, CaseIterable {
+        
+        /// Measurement units should be ranged for an adult.
+        case adult
+        
+        /// Measurement units should be ranged for a child.
+        case child
+        
+        /// Measuremet units should be ranged for an infant.
+        case infant
+    }
+    
+    /// The `DateRangeType` is used to simplify transforming classes on Android.
+    ///
+    /// Android has different classes for the common date components that may be of interest when
+    /// asking the participant about a "date". Because of this, for many cases, that platform does
+    /// not need to define an `RSDDateRange` to differentiate between *which* subset of date
+    /// components should be requested. This form data type is used to differentiate between these
+    /// different types. While on iOS, this requires some custom handling in the data source, it
+    /// greatly simplifies decoding on Android and is thus supported here.
+    ///
+    /// The date range type *only* supports those types that are native to Android. Custom date
+    /// components such as year only or year and month only still require defining the supported
+    /// ranges using the `RSDDateRange` protocol.
+    ///
+    /// Additionally, the `rawValue` key of "date" still maps to `.base(.date)` to maintain
+    /// reverse-compatibility to existing JSON-encoded objects.
+    ///
+    public enum DateRangeType: String, CaseIterable {
+        
+        /// Includes time, date, and GMT timezone offset ("yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ").
+        case timestamp
+        
+        /// Includes date only ("yyyy-MM-dd").
+        ///
+        /// - note: This framework already maps the `rawValue` of "date" to the `.base(.date)` data
+        /// type which is a generic that can be used to define dates independently of which
+        /// components are displayed to the user.
+        case dateOnly
+        
+        /// Includes time only ("HH:mm:ss").
+        ///
+        /// - note: Use a custom naming key of "time" to match the `rawValue` already defined for
+        /// Android.
+        case timeOnly = "time"
+
+        /// The default coding date format.
+        public var dateFormat: String {
+            switch self {
+            case .timestamp:
+                return RSDDateCoderObject.timestamp.rawValue
+            case .dateOnly:
+                return RSDDateCoderObject.dateOnly.rawValue
+            case .timeOnly:
+                return RSDDateCoderObject.timeOfDay.rawValue
+            }
+        }
+    }
+    
+    /// The `BaseType` for this form type. All data types have a base type, though some carry additional information.
+    public var baseType : BaseType {
+        switch self {
+        case .base(let baseType):
+            return baseType
+            
+        case .collection(_, let baseType):
+            return baseType
+            
+        case .dateRange(_):
+            return .date
+            
+        case .measurement(let measurement, _):
+            switch measurement {
+            case .height, .weight:
+                return .decimal
+                
+            case .bloodPressure:
+                return .string
+            }
+        
+        case .postalCode:
+            return .string
+            
+        case .detail(let baseType):
+            return baseType
+            
+        case .custom(_, let baseType):
+            return baseType
+        }
+    }
+    
+    func defaultAnswerType() -> AnswerType {
+        switch self {
+        case .collection(let collectionType, let baseType):
+            if collectionType == .singleChoice {
+                return baseType.jsonType.answerType
+            }
+            else {
+                return AnswerTypeArray(baseType: baseType.jsonType, sequenceSeparator: nil)
+            }
+        case .dateRange(let rangeType):
+            return AnswerTypeDateTime(codingFormat: rangeType.dateFormat)
+        case .measurement(let measurementType, _):
+            switch measurementType {
+            case .bloodPressure:
+                return AnswerTypeString()
+            case .height:
+                return AnswerTypeMeasurement(unit: "cm")
+            case .weight:
+                return AnswerTypeMeasurement(unit: "kg")
+            }
+        default:
+            return baseType.jsonType.answerType
+        }
+    }
+}
+
+fileprivate let kDetailCodingKey = "detail"
+fileprivate let kPostalCodeCodingKey = "postalCode"
+
+extension SBAProfileDataType: RawRepresentable, Codable, Hashable {
+    
+    public init?(rawValue: String) {
+        let split = rawValue.components(separatedBy: ".")
+        if split.count == 1, let subtype = BaseType(rawValue: rawValue) {
+            self = .base(subtype)
+        }
+        else if split.count == 1, let rangeType = DateRangeType(rawValue: rawValue) {
+            self = .dateRange(rangeType)
+        }
+        else if split.count <= 2, let collectionType = CollectionType(rawValue: split[0]) {
+            let baseType: BaseType = ((split.count == 2) ? BaseType(rawValue: split[1]) : nil) ?? .string
+            self = .collection(collectionType, baseType)
+        }
+        else if split.count <= 2, let measurementType = MeasurementType(rawValue: split[0]) {
+            let range: MeasurementRange = ((split.count == 2) ? MeasurementRange(rawValue: split[1]) : nil) ?? .adult
+            self = .measurement(measurementType, range)
+        }
+        else if rawValue == kPostalCodeCodingKey {
+            self = .postalCode
+        }
+        else {
+            let subtype: BaseType = {
+                guard split.count == 2, let subtype = BaseType(rawValue: split[1])
+                    else {
+                        return .codable
+                }
+                return subtype
+            }()
+            let typeValue = split[0]
+            if typeValue == kDetailCodingKey {
+                self = .detail(subtype)
+            }
+            else {
+                self = .custom(typeValue, subtype)
+            }
+        }
+    }
+    
+    public var rawValue: String {
+        switch (self) {
+        case .base(let value):
+            return value.rawValue
+            
+        case .collection(let collectionType, let baseType):
+            return "\(collectionType.rawValue).\(baseType.rawValue)"
+            
+        case .dateRange(let rangeType):
+            return rangeType.rawValue
+        
+        case .measurement(let measurement, let range):
+            return "\(measurement.rawValue).\(range.rawValue)"
+            
+        case .detail(let baseType):
+            if baseType == .codable {
+                return kDetailCodingKey
+            }
+            else {
+                return "\(kDetailCodingKey).\(baseType.rawValue)"
+            }
+        
+        case .postalCode:
+            return kPostalCodeCodingKey
+            
+        case .custom(let value, let baseType):
+            if baseType == .string {
+                return value
+            }
+            else {
+                return "\(value).\(baseType.rawValue)"
+            }
+        }
+    }
+}
+
+extension SBAProfileDataType : ExpressibleByStringLiteral {
+
+    public init(stringLiteral value: String) {
+        self.init(rawValue: value)!
+    }
+}
+
+extension SBAProfileDataType.BaseType {
+    
+    var jsonType : JsonType {
+        switch self {
+        case .boolean: return .boolean
+        case .codable: return .object
+        case .date: return .string
+        case .decimal: return .number
+        case .duration: return .number
+        case .fraction: return .string
+        case .integer: return .integer
+        case .string: return .string
+        case .year: return .integer
+        }
+    }
+}

--- a/BridgeApp/BridgeApp/Profile/SBAProfileDataType.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileDataType.swift
@@ -2,8 +2,34 @@
 //  SBAProfileDataType.swift
 //  BridgeApp (iOS)
 //
-//  Created by Shannon Young on 8/24/20.
 //  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import Foundation

--- a/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
+++ b/BridgeApp/BridgeApp/Profile/SBAProfileItem.swift
@@ -55,7 +55,7 @@ public protocol SBAProfileItem: class, Decodable {
     var demographicKey: String { get }
     
     /// itemType specifies what type to store the profileItem's value as. Defaults to String if not otherwise specified.
-    var itemType: RSDFormDataType { get }
+    var itemType: SBAProfileDataType { get }
     
     /// Is the value read-only?
     var readonly: Bool { get }
@@ -142,9 +142,8 @@ extension SBAProfileItem {
     /// Used in the setters for the profile items to set a new value to client data.
     public func commonItemTypeToBridgeJson(val: Any?) -> SBBJSONValue {
         do {
-            let answerType = self.itemType.defaultAnswerResultType()
-            let ret = try answerType.jsonEncode(from: val)
-            guard let json = ret else { return NSNull() }
+            let answerType = self.itemType.defaultAnswerType()
+            let json = try answerType.encodeAnswer(from: val)
             return json.toClientData()
         }
         catch let err {
@@ -159,8 +158,8 @@ extension SBAProfileItem {
         }
         
         do {
-            let answerType = self.itemType.defaultAnswerResultType()
-            return try answerType.jsonDecode(from: jsonVal.toJSONSerializable(), with: self.itemType)
+            let answerType = self.itemType.defaultAnswerType()
+            return try answerType.decodeAnswer(from: jsonVal.toJsonElement())
         }
         catch let err {
             if self.itemType == .base(.string) {
@@ -223,7 +222,7 @@ public final class SBAReportProfileItem: SBAProfileItemInternal {
     }
 
     /// itemType specifies what type to store the profileItem's value as. Defaults to String if not otherwise specified.
-    public var itemType: RSDFormDataType
+    public var itemType: SBAProfileDataType
     
     /// The class type to which to deserialize this profile item.
     public var type: SBAProfileItemType
@@ -311,7 +310,7 @@ public final class SBADataGroupProfileItem: SBAProfileItemInternal {
 
     /// `itemType` specifies what type to store the profileItem's value as. Defaults to String if not
     /// otherwise specified.
-    public var itemType: RSDFormDataType
+    public var itemType: SBAProfileDataType
     
     /// The class type to which to deserialize this profile item.
     public var type: SBAProfileItemType
@@ -445,7 +444,7 @@ public final class SBAStudyParticipantProfileItem: SBAProfileItemInternal {
     public var demographicSchema: String?
     
     /// itemType specifies what type to store the profileItem's value as. Defaults to String if not otherwise specified.
-    public var itemType: RSDFormDataType
+    public var itemType: SBAProfileDataType
     
     /// Is the value read-only?
     /// Note that if the underlying SBBStudyParticipant field is effectively read-only, this
@@ -531,7 +530,7 @@ public final class SBAStudyParticipantClientDataProfileItem: SBAProfileItemInter
     public var demographicSchema: String?
     
     /// itemType specifies what type to store the profileItem's value as. Defaults to String if not otherwise specified.
-    public var itemType: RSDFormDataType
+    public var itemType: SBAProfileDataType
     
     /// The class type to which to deserialize this profile item.
     public var type: SBAProfileItemType

--- a/BridgeApp/BridgeApp/Research Model/SBBJSONValue+RSDJSONSerializable.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBBJSONValue+RSDJSONSerializable.swift
@@ -34,6 +34,12 @@
 import Foundation
 import JsonModel
 
+public extension JsonElement {
+    func toClientData() -> SBBJSONValue {
+        self.jsonObject().toClientData()
+    }
+}
+
 public extension JsonSerializable {
     func toClientData() -> SBBJSONValue {
         guard let data = self as? SBBJSONValue else {
@@ -47,6 +53,19 @@ public extension JsonSerializable {
 }
 
 public extension SBBJSONValue {
+    
+    func toJsonElement() -> JsonElement {
+        if let jsonValue = self as? JsonValue {
+            return JsonElement(jsonValue)
+        }
+        else {
+            // Note: syoung 05/07/2019 All implementations of SBBJSONValue should be tested so this is
+            // unexpected to happen. Nevertheless, if it does happen, only crash in Debug and not in Release.
+            assertionFailure("Failed to convert \(self) to JsonElement")
+            return .null
+        }
+    }
+    
     func toJSONSerializable() -> JsonSerializable {
         if let data = self as? JsonSerializable {
             return data

--- a/BridgeApp/BridgeApp/Research Model/SBBSurveyRule+RSDSurveyRule.swift
+++ b/BridgeApp/BridgeApp/Research Model/SBBSurveyRule+RSDSurveyRule.swift
@@ -74,7 +74,13 @@ extension SBBSurveyInfoScreen : RSDNavigationRule {
     }
 }
 
-extension SBBSurveyQuestion : RSDSurveyNavigationStep {
+extension SBBSurveyQuestion : SurveyRuleNavigation {
+    
+    /// Only return the rules that are valid comparable rules
+    public var surveyRules: [RSDSurveyRule] {
+        guard let rules = self.constraints.rules as? [SBBSurveyRule] else { return [] }
+        return rules.filter { $0.isValidComparableRule }
+    }
     
     /// Look at the after rules for a skip rule and return the `skipToIdentifier` for that rule.
     public var skipToIfNil: String? {
@@ -95,15 +101,6 @@ extension SBBSurveyQuestion : RSDCohortAssignmentStep {
     
     public func cohortsToApply(with result: RSDTaskResult) -> (add: Set<String>, remove: Set<String>)? {
         return self.evaluateCohortsToApply(with: result)
-    }
-}
-
-extension sbb_InputField {
-    
-    /// Only return the rules that are valid comparable rules
-    public var surveyRules: [RSDSurveyRule]? {
-        guard let rules = self.constraints.rules as? [SBBSurveyRule] else { return nil }
-        return rules.filter { $0.isValidComparableRule }
     }
 }
 

--- a/BridgeApp/BridgeApp/Research Model/TextConstraintWrapper.swift
+++ b/BridgeApp/BridgeApp/Research Model/TextConstraintWrapper.swift
@@ -2,8 +2,34 @@
 //  TextConstraintWrapper.swift
 //  BridgeApp (iOS)
 //
-//  Created by Shannon Young on 8/20/20.
 //  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 import Foundation

--- a/BridgeApp/BridgeApp/Research Model/TextConstraintWrapper.swift
+++ b/BridgeApp/BridgeApp/Research Model/TextConstraintWrapper.swift
@@ -1,0 +1,72 @@
+//
+//  TextConstraintWrapper.swift
+//  BridgeApp (iOS)
+//
+//  Created by Shannon Young on 8/20/20.
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+
+import Foundation
+
+class AbstractTextConstraintsWrapper {
+    
+    var answerType: AnswerType { question.answerType }
+    
+    var identifier: String? { nil }
+    
+    var inputUIHint: RSDFormUIHint { question.uiHintValue?.hint ?? .textfield }
+    
+    var fieldLabel: String? { nil }
+    
+    let placeholder: String?
+    
+    var isOptional: Bool { question.isOptional }
+    
+    var isExclusive: Bool { true }
+
+    let question: SBBSurveyQuestion
+    
+    init(question: SBBSurveyQuestion) {
+        self.question = question
+        self.placeholder = (question.constraints as? sbb_PatternPlaceholder)?.patternPlaceholder
+    }
+}
+
+class TextEntryConstraintsWrapper : AbstractTextConstraintsWrapper, KeyboardTextInputItem {
+    
+    let keyboardOptions: KeyboardOptions
+    
+    override init(question: SBBSurveyQuestion) {
+        self.keyboardOptions = (question.constraints as? sbb_KeyboardOptionsBuilder)?.buildKeyboardOptions() ?? KeyboardOptionsObject()
+        super.init(question: question)
+    }
+    
+    func buildTextValidator() -> TextInputValidator {
+        (question.constraints as? sbb_TextValidatorBuilder)?.buildTextValidator() ?? PassThruValidator()
+    }
+    
+    func buildPickerSource() -> RSDPickerDataSource? {
+        question.constraints as? RSDPickerDataSource
+    }
+}
+ 
+class DateEntryConstraintsWrapper : AbstractTextConstraintsWrapper, KeyboardTextInputItem {
+    
+    var keyboardOptions: KeyboardOptions {
+        KeyboardOptionsObject.dateTimeEntryOptions
+    }
+    
+    func buildTextValidator() -> TextInputValidator {
+        guard let pickerMode = (self.question.constraints as? RSDDatePickerDataSource)?.datePickerMode
+            else {
+                assertionFailure("Expected that the `DateEntryConstraintsWrapper` constraints will implement the `RSDDatePickerDataSource` protocol.")
+                return PassThruValidator()
+        }
+        let formatOptions = self.question.constraints as? RSDDateRange
+        return DateTimeValidator(pickerMode: pickerMode, range: formatOptions)
+    }
+    
+    func buildPickerSource() -> RSDPickerDataSource? {
+        self.question.constraints as? RSDDatePickerDataSource
+    }
+}

--- a/BridgeApp/BridgeApp/Study Management/SBAScheduledActivityArchive.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBAScheduledActivityArchive.swift
@@ -96,7 +96,7 @@ open class SBAScheduledActivityArchive: SBBDataArchive, RSDDataArchive {
     
     /// Get the archivable object for the given result.
     open func archivableData(for result: RSDResult, sectionIdentifier: String?, stepPath: String?) -> RSDArchivable? {
-        if self.usesV1LegacySchema, let answerResult = result as? RSDAnswerResult {
+        if self.usesV1LegacySchema, let answerResult = result as? AnswerResultObject {
             return SBAAnswerResultWrapper(sectionIdentifier: sectionIdentifier, result: answerResult)
         }
         else if let archivable = result as? RSDArchivable {
@@ -188,7 +188,7 @@ private let kNumericResultUnitKey = "unit"
 struct SBAAnswerResultWrapper : RSDArchivable {
     
     let sectionIdentifier : String?
-    let result : RSDAnswerResult
+    let result : AnswerResultObject
 
     var identifier: String {
         if let section = sectionIdentifier {
@@ -206,14 +206,14 @@ struct SBAAnswerResultWrapper : RSDArchivable {
         let item = bridgifyFilename(self.identifier)
 
         json[kIdentifierKey] = result.identifier
-        json[kStartDateKey]  = result.startDate
-        json[kEndDateKey]    = result.endDate
+        json[kStartDateKey] = result.startDate
+        json[kEndDateKey] = result.endDate
         json[kItemKey] = item
-        if let answer = (result.value as? JsonValue)?.jsonObject() {
-            json[result.answerType.bridgeAnswerKey] = answer
+        if let answer = result.jsonValue?.jsonObject() {
+            json[result.bridgeAnswerKey] = answer
             json[kQuestionResultSurveyAnswerKey] = answer
-            json[kQuestionResultQuestionTypeKey] = result.answerType.bridgeAnswerType
-            if let unit = result.answerType.unit {
+            json[kQuestionResultQuestionTypeKey] = result.bridgeAnswerType
+            if let unit = (result.jsonAnswerType as? AnswerTypeMeasurement)?.unit {
                 json[kNumericResultUnitKey] = unit
             }
         }
@@ -225,63 +225,64 @@ struct SBAAnswerResultWrapper : RSDArchivable {
     }
 }
 
-extension RSDAnswerResultType {
+extension AnswerResultObject {
 
     var bridgeAnswerType: String {
-        guard self.sequenceType == nil else {
-            return "MultipleChoice"
+        guard let questionData = self.questionData,
+            case .object(let dictionary) = questionData,
+            let constraintsType = dictionary[kConstraintsType] as? String,
+            let dataType = dictionary[kConstraintsDataType] as? String
+            else {
+                return "Text"
         }
-
-        if let dataType = self.formDataType,
-            case .collection(let collectionType, _) = dataType,
-            collectionType == .singleChoice {
-            return "SingleChoice"
+        
+        if constraintsType == SBBMultiValueConstraints().type {
+            return (self.jsonAnswerType is AnswerTypeArray) ? "MultipleChoice" : "SingleChoice"
         }
-
-        switch self.baseType {
-        case .boolean:
-            return "Boolean"
-        case .string, .data, .codable:
-            return "Text"
-        case .integer:
-            return "Integer"
-        case .decimal:
-            return "Decimal"
-        case .date:
-            if self.dateFormat == "HH:mm:ss" || self.dateFormat == "HH:mm" {
-                return "TimeOfDay"
-            } else {
+        else {
+            switch SBBDataType(rawValue: dataType) {
+            case .boolean:
+                return "Boolean"
+            case .integer:
+                return "Integer"
+            case .decimal, .duration, .height, .weight:
+                return "Decimal"
+            case .date, .dateTime:
                 return "Date"
+            case .time:
+                return "TimeOfDay"
+            default:
+                return "Text"
             }
         }
     }
 
     var bridgeAnswerKey: String {
-        guard self.sequenceType == nil else {
+        guard let questionData = self.questionData,
+            case .object(let dictionary) = questionData,
+            let constraintsType = dictionary[kConstraintsType] as? String,
+            let dataType = dictionary[kConstraintsDataType] as? String
+            else {
+                return "textAnswer"
+        }
+        
+        if constraintsType == SBBMultiValueConstraints().type {
             return "choiceAnswers"
         }
-
-        if let dataType = self.formDataType,
-            case .collection(let collectionType, _) = dataType,
-            collectionType == .singleChoice {
-            return "choiceAnswers"
-        }
-
-        switch self.baseType {
-        case .boolean:
-            return "booleanAnswer"
-        case .string, .data, .codable:
-            return "textAnswer"
-        case .integer, .decimal:
-            return "numericAnswer"
-        case .date:
-            if self.dateFormat == "HH:mm:ss" || self.dateFormat == "HH:mm" {
-                return "dateComponentsAnswer"
-            } else {
+        else {
+            switch SBBDataType(rawValue: dataType) {
+            case .boolean:
+                return "booleanAnswer"
+            case .integer, .decimal, .duration, .height, .weight:
+                return "numericAnswer"
+            case .date, .dateTime:
                 return "dateAnswer"
+            case .time:
+                return "dateComponentsAnswer"
+            default:
+                return "textAnswer"
             }
         }
-
     }
 }
 

--- a/BridgeApp/BridgeApp/Study Management/SBASurveyConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBASurveyConfiguration.swift
@@ -57,8 +57,8 @@ open class SBASurveyConfiguration {
     open func stepType(for step: SBBSurveyElement) -> RSDStepType {
         if let stepType = stepTypeMap[step.guid] {
             return stepType
-        } else if step is SBBSurveyQuestion {
-            return .form
+        } else if let question = step as? SBBSurveyQuestion {
+            return (question.constraints is SBBMultiValueConstraints) ? .choiceQuestion : .simpleQuestion
         } else {
             return .instruction
         }
@@ -68,11 +68,20 @@ open class SBASurveyConfiguration {
     /// By default, this will return an instance of `RSDResultObject` for an instruction step
     /// and `RSDCollectionResultObject` for a form step.
     open func instantiateStepResult(for step: SBBSurveyElement) -> RSDResult? {
-        return step is SBBSurveyInfoScreen ? RSDResultObject(identifier: step.identifier) : RSDCollectionResultObject(identifier: step.identifier)
+        if let question = step as? SBBSurveyQuestion {
+            return AnswerResultObject(identifier: question.identifier,
+                                      answerType: question.answerType,
+                                      value: nil,
+                                      questionText: question.prompt,
+                                      questionData: question.questionData)
+        }
+        else {
+            return RSDResultObject(identifier: step.identifier)
+        }
     }
     
     /// Is the input field optional? Default = `true`.
-    open func isOptional(for inputField: RSDInputField) -> Bool {
+    open func isOptional(for inputField: SBBSurveyQuestion) -> Bool {
         return true
     }
     

--- a/BridgeApp/BridgeAppExample/Info.plist
+++ b/BridgeApp/BridgeAppExample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2</string>
+	<string>4.3</string>
 	<key>CFBundleVersion</key>
 	<string>26</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/BridgeApp/BridgeAppTests/Info.plist
+++ b/BridgeApp/BridgeAppTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2</string>
+	<string>4.3</string>
 	<key>CFBundleVersion</key>
 	<string>26</string>
 </dict>

--- a/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
+++ b/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
@@ -502,7 +502,13 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
         
         // Check that the setup method was called as expected
         XCTAssertNotNil(tracker.setupTask_data)
-        XCTAssertEqual(tracker.setupTask_data?.json as? [String : String], ["addedInfo" : "ragu"])
+        if let json = tracker.setupTask_data?.json as? [String : JsonSerializable],
+            let dict = json as? [String : String] {
+            XCTAssertEqual(dict, ["addedInfo" : "ragu"])
+        }
+        else {
+            XCTFail("Failed to setup the task JSON. actual = \(String(describing: tracker.setupTask_data?.json))")
+        }
         
         // step to just before completion
         let _ = taskController.test_stepTo("step4")
@@ -682,7 +688,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
     func convertWithIndex(_ steps: [TestStep]) -> [TestStep] {
         return steps.enumerated().map {
             var step = $1
-            step.result = RSDAnswerResultObject(identifier: step.identifier, answerType: .integer, value: $0)
+            step.result = AnswerResultObject(identifier: step.identifier, value: .integer($0))
             return step
         }
     }
@@ -699,8 +705,8 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
         return steps.map { (inStep) -> TestStep in
             var step = inStep
             var collectionResult = RSDCollectionResultObject(identifier: step.identifier)
-            collectionResult.appendInputResults(with: RSDAnswerResultObject(identifier: "identifier", answerType: .string, value: step.identifier))
-            collectionResult.appendInputResults(with: RSDAnswerResultObject(identifier: "boolean", answerType: .boolean, value: true))
+            collectionResult.appendInputResults(with: AnswerResultObject(identifier: "identifier", value: .string(step.identifier)))
+            collectionResult.appendInputResults(with: AnswerResultObject(identifier: "boolean", value: .boolean(true)))
             step.result = collectionResult
             return step
         }
@@ -710,7 +716,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
         return steps.map { (inStep) -> TestStep in
             var step = inStep
             var collectionResult = RSDCollectionResultObject(identifier: step.identifier)
-            collectionResult.appendInputResults(with: RSDAnswerResultObject(identifier: step.identifier, answerType: .integer, value: step.identifier.count))
+            collectionResult.appendInputResults(with: AnswerResultObject(identifier: step.identifier, value: .integer(step.identifier.count)))
             step.result = collectionResult
             return step
         }

--- a/BridgeApp/BridgeAppTests/ScheduleFilteringTests.swift
+++ b/BridgeApp/BridgeAppTests/ScheduleFilteringTests.swift
@@ -299,7 +299,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         
         let taskInfo = RSDTaskInfoObject(with: "test")
         let step = RSDUIStepObject(identifier: "introduction")
-        let task = RSDTaskObject(identifier: "test", stepNavigator: RSDConditionalStepNavigatorObject(with: [step]))
+        let task = AssessmentTaskObject(identifier: "test", steps: [step])
         let schema = SBBSchemaReference(dictionaryRepresentation: ["id" : "test",
                                                                    "revision" : NSNumber(value: 3)])!
         SBABridgeConfiguration.shared.addMapping(with: schema)
@@ -342,7 +342,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         
         let taskInfo = RSDTaskInfoObject(with: "test")
         let step = RSDUIStepObject(identifier: "introduction")
-        let task = RSDTaskObject(identifier: "test", stepNavigator: RSDConditionalStepNavigatorObject(with: [step]))
+        let task = AssessmentTaskObject(identifier: "test", steps: [step])
         let schema = SBBSchemaReference(dictionaryRepresentation: ["id" : "test",
                                                                    "revision" : NSNumber(value: 3)])!
         SBABridgeConfiguration.shared.addMapping(with: schema)
@@ -393,7 +393,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         
         let taskInfo = RSDTaskInfoObject(with: "taskC")
         let step = RSDUIStepObject(identifier: "introduction")
-        let task = RSDTaskObject(identifier: "taskC", stepNavigator: RSDConditionalStepNavigatorObject(with: [step]))
+        let task = AssessmentTaskObject(identifier: "taskC", steps: [step])
         let schema = SBBSchemaReference(dictionaryRepresentation: ["id" : "taskC",
                                                                    "revision" : NSNumber(value: 3)])!
         SBABridgeConfiguration.shared.addMapping(with: schema)
@@ -414,7 +414,7 @@ class ScheduleFilteringTests: SBAScheduleManagerTests {
         
         let taskInfo = RSDTaskInfoObject(with: "test")
         let step = RSDUIStepObject(identifier: "introduction")
-        let task = RSDTaskObject(identifier: "test", stepNavigator: RSDConditionalStepNavigatorObject(with: [step]))
+        let task = AssessmentTaskObject(identifier: "test", steps: [step])
         let schema = SBBSchemaReference(dictionaryRepresentation: ["id" : "test",
                                                                    "revision" : NSNumber(value: 3)])!
         SBABridgeConfiguration.shared.addMapping(with: schema)

--- a/BridgeApp/BridgeAppTests/SurveyNavigationRuleTests.swift
+++ b/BridgeApp/BridgeAppTests/SurveyNavigationRuleTests.swift
@@ -80,30 +80,24 @@ class SurveyNavigationRuleTests: XCTestCase {
         ruleNo.endSurveyValue = true
         constraints.addRulesObject(ruleNo)
         
-        var answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .boolean)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
+        let answerResult = inputStep.instantiateAnswerResult()
         var taskResult = RSDTaskResultObject(identifier: "test")
+        taskResult.appendStepHistory(with: answerResult)
         
         // Set the answer to "yes"
-        answerResult.value = true
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .boolean(true)
         
         let identifierYes = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertEqual(identifierYes, "keepGoing")
         
         // Set the answer to "no"
-        answerResult.value = false
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .boolean(false)
         
         let identifierNo = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertEqual(identifierNo, "nextSection")
         
         // Set the answer to "skip"
-        answerResult.value = nil
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = nil
         
         let identifierSkip = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertNil(identifierSkip)
@@ -138,38 +132,31 @@ class SurveyNavigationRuleTests: XCTestCase {
         ruleNo.endSurveyValue = true
         constraints.addRulesObject(ruleNo)
         
-        var answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .string)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
+        let answerResult = AnswerResultObject(identifier: inputStep.identifier, answerType: AnswerTypeString())
         var taskResult = RSDTaskResultObject(identifier: "test")
+        taskResult.appendStepHistory(with: answerResult)
         
         // Set the answer to "yes"
-        answerResult.value = "true"
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .string("true")
+        
         
         let identifierYes = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertEqual(identifierYes, "keepGoing")
         
         // Set the answer to "no"
-        answerResult.value = "false"
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .string("false")
         
         let identifierNo = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertEqual(identifierNo, "nextSection")
         
         // Set the answer to "maybe"
-        answerResult.value = "maybe"
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .string("maybe")
         
         let identifierMaybe = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertNil(identifierMaybe)
         
         // Set the answer to "skip"
-        answerResult.value = nil
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = nil
         
         let identifierSkip = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertNil(identifierSkip)
@@ -226,23 +213,17 @@ class SurveyNavigationRuleTests: XCTestCase {
         rule.value = NSNumber(value: 1)
         constraints.addRulesObject(rule)
         
-        var answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .integer)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
+        let answerResult = AnswerResultObject(identifier: inputStep.identifier, answerType: AnswerTypeInteger())
         var taskResult = RSDTaskResultObject(identifier: "test")
+        taskResult.appendStepHistory(with: answerResult)
         
         // Set the answer to invalid
-        answerResult.value = 0
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
-        
+        answerResult.jsonValue = .integer(0)
         let identifier1 = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertNil(identifier1)
         
         // Set the answer to valid
-        answerResult.value = 1
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
-        
+        answerResult.jsonValue = .integer(1)
         let identifier2 = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertEqual(identifier2, "correct")
     }
@@ -260,22 +241,18 @@ class SurveyNavigationRuleTests: XCTestCase {
         rule.value = NSNumber(value: 1)
         constraints.addRulesObject(rule)
         
-        var answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .integer)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
+        let answerResult = AnswerResultObject(identifier: inputStep.identifier, answerType: AnswerTypeInteger())
         var taskResult = RSDTaskResultObject(identifier: "test")
+        taskResult.appendStepHistory(with: answerResult)
         
         // Set the answer to invalid
-        answerResult.value = 1
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .integer(1)
         
         let identifier1 = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertNil(identifier1)
         
         // Set the answer to valid
-        answerResult.value = 0
-        stepResult.appendInputResults(with: answerResult)
-        taskResult.appendStepHistory(with: stepResult)
+        answerResult.jsonValue = .integer(0)
         
         let identifier2 = surveyStep.nextStepIdentifier(with: taskResult, isPeeking: false)
         XCTAssertEqual(identifier2, "correct")

--- a/BridgeApp/BridgeAppUI/Info.plist
+++ b/BridgeApp/BridgeAppUI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2</string>
+	<string>4.3</string>
 	<key>CFBundleVersion</key>
 	<string>26</string>
 </dict>

--- a/BridgeApp/BridgeAppUI/iOS/SBACatastrophicErrorViewController.swift
+++ b/BridgeApp/BridgeAppUI/iOS/SBACatastrophicErrorViewController.swift
@@ -50,7 +50,7 @@ class SBACatastrophicErrorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        appNameLabel.text = Localization.localizedAppName
+        appNameLabel.text = currentPlatformContext.appName
         logoImageView.image = UIImage(named: "logo")
         
         if let message = initialMessage {
@@ -68,7 +68,7 @@ class SBACatastrophicErrorViewController: UIViewController {
         messageLabel.text = message
         
         // If the button title is nil set to default title.
-        let buttonTitle = buttonText ?? String.localizedStringWithFormat(Localization.localizedString("UPDATE_APP_BUTTON"), Localization.localizedAppName)
+        let buttonTitle = buttonText ?? String.localizedStringWithFormat(Localization.localizedString("UPDATE_APP_BUTTON"), currentPlatformContext.appName)
         actionButton.setTitle(buttonTitle, for: UIControl.State())
         
         // If the action handler is nil then set to default of opening the app for update.

--- a/BridgeApp/DataTracking/Info.plist
+++ b/BridgeApp/DataTracking/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2</string>
+	<string>4.3</string>
 	<key>CFBundleVersion</key>
 	<string>26</string>
 </dict>

--- a/BridgeApp/DataTrackingTests/Info.plist
+++ b/BridgeApp/DataTrackingTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2</string>
+	<string>4.3</string>
 	<key>CFBundleVersion</key>
 	<string>26</string>
 </dict>

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Sage-Bionetworks/SageResearch" ~> 3.7
+github "Sage-Bionetworks/SageResearch" ~> 3.9
 github "Sage-Bionetworks/Bridge-iOS-SDK" ~> 4.2.72

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "v4.2.75"
-github "Sage-Bionetworks/SageResearch" "v3.7.96"
+github "Sage-Bionetworks/SageResearch" "v3.9.98"


### PR DESCRIPTION
This cleans up most of the deprecation warnings by implementing the Bridge 1.0 survey question types that are used in current applications and supported by mPower 2.0 Android. I left one deprecation warning related to `RSDTaskObject`. We aren't using that in the AppConfig, but it isn't straight-forward to delete it without possibly impacting our partner's applications.

Additionally, I did not look at refactoring the data tracking. That is a separate framework that is only used on mPower 2.0 *and* will need to be refactored to be supported going forward by a Kotlin native cross platform solution.