### PR TITLE
Update BridgeApp to point to ResearchUI so that the bundle can be properly loaded

### DIFF
--- a/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
+++ b/BridgeApp/BridgeApp.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		FFA07189235801EE00EA371F /* SBAMedicationFollowupTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA07188235801EE00EA371F /* SBAMedicationFollowupTask.swift */; };
 		FFF2968F24EF2C52000E36FB /* TextConstraintWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF2968E24EF2C52000E36FB /* TextConstraintWrapper.swift */; };
 		FFF2969324F454B9000E36FB /* SBAProfileDataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF2969224F454B9000E36FB /* SBAProfileDataType.swift */; };
+		FFF6F439254236FD00130EDD /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F87D2ACB22780599007CA2B5 /* ResearchUI.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -377,6 +378,7 @@
 			files = (
 				FF29AAAB24492FB100C39E02 /* Research.framework in Frameworks */,
 				FF29AAA924492FAF00C39E02 /* BridgeSDK.framework in Frameworks */,
+				FFF6F439254236FD00130EDD /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
+++ b/BridgeApp/BridgeApp/Study Management/SBABridgeConfiguration.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import BridgeSDK
+import ResearchUI
 
 
 /// Override the default task repository to include transforming from surveys, compound activities, and other

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Sage-Bionetworks/Bridge-iOS-SDK" "v4.2.75"
-github "Sage-Bionetworks/SageResearch" "v3.9.98"
+github "Sage-Bionetworks/SageResearch" "v3.13.5"


### PR DESCRIPTION
All references to bundles were moved from the Research to ResearchUI frameworks. I missed one of the references in BridgeApp and now ResearchUI needs to be included in that framework. Note: This means that BridgeApp cannot build for anything but iOS right now, but it didn't anyway. ¯\_(ツ)_/¯ 

