### PR TITLE
Implement missing app delegate method

### DIFF
--- a/BridgeApp/BridgeAppUI/iOS/SBAAppDelegate.swift
+++ b/BridgeApp/BridgeAppUI/iOS/SBAAppDelegate.swift
@@ -74,6 +74,11 @@ open class SBAAppDelegate : RSDAppDelegate, SBBBridgeErrorUIDelegate {
         rootViewController?.contentHidden = false
     }
     
+    open func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
+        if identifier == kBackgroundSessionIdentifier {
+            BridgeSDK.restoreBackgroundSession(identifier, completionHandler: completionHandler)
+        }
+    }
 
     // ------------------------------------------------
     // MARK: RootViewController management


### PR DESCRIPTION
needed for Bridge apps to handle BackgroundURLSession events (related to file uploads) that come in when the app is relaunched into the background