### PR TITLE
Bump to SageResearch 4.4.0

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,13 +8,11 @@ on:
 
 jobs:
   unit_tests:
-    runs-on: macos-11
+    runs-on: macos-latest
     steps:
     - name: Repository checkout
       uses: actions/checkout@v2
-    - name: Force Xcode 13.1
-      run: sudo xcode-select -switch /Applications/Xcode_13.1.app
     - name: Build for iOS
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -scheme BridgeApp-Package -destination "platform=iOS Simulator,OS=15.0,name=iPhone 12" | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -scheme BridgeApp-Package -destination "platform=iOS Simulator,OS=15.2,name=iPhone 12" | xcpretty
     - name: Run iOS tests
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -scheme BridgeApp-Package -destination "platform=iOS Simulator,OS=15.0,name=iPhone 12" | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -scheme BridgeApp-Package -destination "platform=iOS Simulator,OS=15.2,name=iPhone 12" | xcpretty

--- a/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Protocols/RSDAnswerResult.swift
+++ b/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Protocols/RSDAnswerResult.swift
@@ -63,6 +63,25 @@ extension RSDAnswerResult {
     }
 }
 
+extension AnswerResultObject : RSDAnswerResult {
+    public var answerType: RSDAnswerResultType {
+        self.jsonAnswerType.map {
+            switch $0 {
+            case is AnswerTypeBoolean:
+                return .boolean
+            case is AnswerTypeDateTime:
+                return .date
+            case is AnswerTypeInteger:
+                return .integer
+            case is AnswerTypeNumber:
+                return .decimal
+            default:
+                return .string
+            }
+        } ?? .string
+    }
+}
+
 /// `RSDAnswerResultFinder` is a convenience protocol used to retrieve an answer result. It is used in
 /// survey navigation to find the result for a given input field.
 ///

--- a/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Protocols/RSDCollectionResult.swift
+++ b/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Protocols/RSDCollectionResult.swift
@@ -50,7 +50,7 @@ public extension RSDCollectionResult {  // RSDAnswerResultFinder
     /// - parameter identifier: The identifier associated with the result.
     /// - returns: The result or `nil` if not found.
     func findAnswerResult(with identifier:String ) -> RSDAnswerResult? {
-        return self.findResult(with: identifier) as? RSDAnswerResult
+        self.children.first(where: { $0.identifier == identifier }) as? RSDAnswerResult
     }
 }
 

--- a/BridgeApp/BridgeApp/iOS/Study Management/SBAArchiveManager.swift
+++ b/BridgeApp/BridgeApp/iOS/Study Management/SBAArchiveManager.swift
@@ -34,6 +34,7 @@
 import Foundation
 import BridgeSDK
 import Research
+import JsonModel
 
 open class SBAArchiveManager : NSObject, RSDDataArchiveManager {
     

--- a/BridgeApp/BridgeApp/iOS/Study Management/SBAScheduleManager.swift
+++ b/BridgeApp/BridgeApp/iOS/Study Management/SBAScheduleManager.swift
@@ -34,6 +34,7 @@
 import Foundation
 import BridgeSDK
 import Research
+import JsonModel
 
 extension Notification.Name {
     

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "18cb823bf75f24a66e631b2a653fcfa4e532f108",
-          "version": "1.3.6"
+          "revision": "b828a14b255c849199032b6d7eaec0e6be025115",
+          "version": "1.4.6"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/SageResearch.git",
         "state": {
           "branch": null,
-          "revision": "ca455e92ae43ea898bef645a4b429324d320c94f",
-          "version": "4.3.8"
+          "revision": "609d7ffd86024f1db94391c9aad1b908020536c3",
+          "version": "4.4.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,24 +22,17 @@ let package = Package(
         .library(
             name: "BridgeApp_UnitTest",
             targets: ["BridgeApp_UnitTest"]),
-        .library(
-            name: "DataTracking",
-            targets: ["DataTracking"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(
             name: "SageResearch",
             url: "https://github.com/Sage-Bionetworks/SageResearch.git",
-            "4.2.4"..<"4.4.0"),
+            from: "4.4.0"),
         .package(
             name: "BridgeSDK",
             url: "https://github.com/Sage-Bionetworks/Bridge-iOS-SDK.git",
             from: "4.4.85"),
-        .package(
-            name: "JsonModel",
-            url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-            from: "1.2.3"),
     ],
     targets: [
 
@@ -49,7 +42,6 @@ let package = Package(
                 .product(name: "BridgeSDK", package: "BridgeSDK"),
                 .product(name: "Research", package: "SageResearch"),
                 .product(name: "ResearchUI", package: "SageResearch"),
-                "JsonModel",
             ],
             path: "BridgeApp/BridgeApp/iOS",
             resources: [
@@ -97,29 +89,5 @@ let package = Package(
                     .linkedFramework("BridgeSDK")
                 ]
                ),
-        
-        .target(name: "DataTracking",
-                dependencies: [
-                    .product(name: "Research", package: "SageResearch"),
-                    .product(name: "ResearchUI", package: "SageResearch"),
-                    "BridgeApp",
-                    "BridgeAppUI",
-                    "JsonModel",
-                ],
-                path: "DataTracking/DataTracking/iOS",
-                resources: [
-                    .process("Resources"),
-                ]
-            ),
-        
-        .testTarget(name: "DataTrackingTests",
-                    dependencies: [
-                        "DataTracking",
-                        .product(name: "Research_UnitTest", package: "SageResearch"),
-                    ],
-                    path: "DataTracking/DataTrackingTests",
-                    resources: [
-                        .process("Resources"),
-                    ]),
     ]
 )


### PR DESCRIPTION
This allows pinning to either a version that works before 4.4.0 or after 4.4.0