### PR TITLE
Test against SR v4.4 to SR v4.5 and JsonModel v1.4.6  to JsonModel v1.4.8

### DIFF
--- a/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/DataSource/RSDFormStepDataSourceObject.swift
+++ b/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/DataSource/RSDFormStepDataSourceObject.swift
@@ -109,7 +109,7 @@ open class RSDFormStepDataSourceObject : RSDStepViewModel, RSDTableDataSource {
     ///
     /// - returns: The appropriate collection result.
     open func instantiateCollectionResult() -> RSDCollectionResult {
-        return RSDCollectionResultObject(identifier: step.identifier)
+        return CollectionResultObject(identifier: step.identifier)
     }
     
     /// Instantiate the appropriate answer result for the given item group.
@@ -185,7 +185,7 @@ open class RSDFormStepDataSourceObject : RSDStepViewModel, RSDTableDataSource {
     private func _answerDidChange(for itemGroup: RSDInputFieldTableItemGroup, at indexPath: IndexPath) {
         
         // Update the answers
-        var stepResult = self.collectionResult()
+        let stepResult = self.collectionResult()
         if let result = self.instantiateAnswerResult(for: itemGroup) {
             stepResult.appendInputResults(with: result)
         } else {
@@ -339,7 +339,7 @@ open class RSDFormStepDataSourceObject : RSDStepViewModel, RSDTableDataSource {
             return parentPath.previousTaskData?.json as? [String : JsonSerializable]
         }()
         
-        var stepResult = self.collectionResult()
+        let stepResult = self.collectionResult()
         var hasChanges: Bool = false
         
         func appendResults(for itemGroup: RSDInputFieldTableItemGroup) {

--- a/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Model/RSDAnswerResultType.swift
+++ b/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Model/RSDAnswerResultType.swift
@@ -214,7 +214,7 @@ extension RSDAnswerResultType {
             return AnswerTypeMeasurement(unit: unit)
         }
         else if self.baseType == .date {
-            return AnswerTypeDateTime(codingFormat: self.dateFormat)
+            return self.dateFormat.map { AnswerTypeDateTime(codingFormat: $0) } ?? AnswerTypeDateTime()
         }
         else {
             return self.baseType.jsonType.answerType

--- a/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Model/RSDFormUIStepObject.swift
+++ b/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Model/RSDFormUIStepObject.swift
@@ -205,7 +205,7 @@ open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNaviga
     /// `RSDCollectionResultObject`.
     /// - returns: A result for this step.
     open override func instantiateStepResult() -> ResultData {
-        return RSDCollectionResultObject(identifier: self.identifier)
+        CollectionResultObject(identifier: self.identifier)
     }
 
     /// Validate the step to check for any configuration that should throw an error. This class will

--- a/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Protocols/RSDCollectionResult.swift
+++ b/BridgeApp/BridgeApp/iOS/BridgeToResearchV1/Protocols/RSDCollectionResult.swift
@@ -56,3 +56,6 @@ public extension RSDCollectionResult {  // RSDAnswerResultFinder
 
 extension RSDCollectionResultObject : RSDCollectionResult {
 }
+
+extension CollectionResultObject : RSDCollectionResult {
+}

--- a/BridgeApp/BridgeApp/iOS/Research Model/SBBSurveyElement+RSDStep.swift
+++ b/BridgeApp/BridgeApp/iOS/Research Model/SBBSurveyElement+RSDStep.swift
@@ -82,7 +82,7 @@ extension SBBSurveyElement : RSDUIStep {
     }
     
     public func instantiateStepResult() -> ResultData {
-        SBASurveyConfiguration.shared.instantiateStepResult(for: self) ?? RSDResultObject(identifier: self.identifier)
+        SBASurveyConfiguration.shared.instantiateStepResult(for: self) ?? ResultObject(identifier: self.identifier)
     }
     
     fileprivate func parseNewLine(_ string: String?) -> String? {

--- a/BridgeApp/BridgeApp/iOS/Study Management/SBASurveyConfiguration.swift
+++ b/BridgeApp/BridgeApp/iOS/Study Management/SBASurveyConfiguration.swift
@@ -75,7 +75,7 @@ open class SBASurveyConfiguration {
     /// By default, this will return an instance of `RSDResultObject` for an instruction step
     /// and `RSDCollectionResultObject` for a form step.
     open func instantiateStepResult(for step: SBBSurveyElement) -> ResultData? {
-        return step is SBBSurveyInfoScreen ? RSDResultObject(identifier: step.identifier) : RSDCollectionResultObject(identifier: step.identifier)
+        return step is SBBSurveyInfoScreen ? ResultObject(identifier: step.identifier) : CollectionResultObject(identifier: step.identifier)
     }
     
     /// Is the input field optional? Default = `true`.

--- a/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
+++ b/BridgeApp/BridgeAppTests/ScheduleArchivingTests.swift
@@ -696,7 +696,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
     func convertForInstruction(_ steps: [TestStep]) -> [TestStep] {
         return steps.map { (inStep) -> TestStep in
             var step = inStep
-            step.result = RSDResultObject(identifier: step.identifier)
+            step.result = ResultObject(identifier: step.identifier)
             return step
         }
     }
@@ -704,7 +704,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
     func convertForCollection(_ steps: [TestStep]) -> [TestStep] {
         return steps.map { (inStep) -> TestStep in
             var step = inStep
-            var collectionResult = RSDCollectionResultObject(identifier: step.identifier)
+            let collectionResult = CollectionResultObject(identifier: step.identifier)
             collectionResult.appendInputResults(with: RSDAnswerResultObject(identifier: "identifier", answerType: .string, value: step.identifier))
             collectionResult.appendInputResults(with: RSDAnswerResultObject(identifier: "boolean", answerType: .boolean, value: true))
             step.result = collectionResult
@@ -715,7 +715,7 @@ class ScheduleArchivingTests: SBAScheduleManagerTests {
     func convertForQuestion(_ steps: [TestStep]) -> [TestStep] {
         return steps.map { (inStep) -> TestStep in
             var step = inStep
-            var collectionResult = RSDCollectionResultObject(identifier: step.identifier)
+            let collectionResult = CollectionResultObject(identifier: step.identifier)
             collectionResult.appendInputResults(with: RSDAnswerResultObject(identifier: step.identifier, answerType: .integer, value: step.identifier.count))
             step.result = collectionResult
             return step

--- a/BridgeApp/BridgeAppTests/StepProtocolTests.swift
+++ b/BridgeApp/BridgeAppTests/StepProtocolTests.swift
@@ -91,7 +91,7 @@ class StepProtocolTests: XCTestCase {
         XCTAssertNil(inputStep.viewTheme)
         XCTAssertNil(inputStep.colorMapping)
         XCTAssertEqual(inputStep.stepType, .instruction)
-        XCTAssertTrue(inputStep.instantiateStepResult() is RSDResultObject)
+        XCTAssertTrue(inputStep.instantiateStepResult() is ResultObject)
     }
     
     func testSurveyQuestion_Configuration_Default() {
@@ -104,7 +104,7 @@ class StepProtocolTests: XCTestCase {
         XCTAssertNil(inputStep.viewTheme)
         XCTAssertNil(inputStep.colorMapping)
         XCTAssertEqual(inputStep.stepType, .bridgeV1SurveyQuestion)
-        XCTAssertTrue(inputStep.instantiateStepResult() is RSDCollectionResultObject)
+        XCTAssertTrue(inputStep.instantiateStepResult() is CollectionResultObject)
         XCTAssertTrue(inputStep.isOptional)
     }
     

--- a/BridgeApp/BridgeAppTests/SurveyNavigationRuleTests.swift
+++ b/BridgeApp/BridgeAppTests/SurveyNavigationRuleTests.swift
@@ -84,8 +84,8 @@ class SurveyNavigationRuleTests: XCTestCase {
         constraints.addRulesObject(ruleNo)
         
         let answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .boolean)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
-        var taskResult = RSDTaskResultObject(identifier: "test")
+        let stepResult = CollectionResultObject(identifier: inputStep.identifier)
+        let taskResult = RSDTaskResultObject(identifier: "test")
         
         // Set the answer to "yes"
         answerResult.value = true
@@ -142,8 +142,8 @@ class SurveyNavigationRuleTests: XCTestCase {
         constraints.addRulesObject(ruleNo)
         
         let answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .string)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
-        var taskResult = RSDTaskResultObject(identifier: "test")
+        let stepResult = CollectionResultObject(identifier: inputStep.identifier)
+        let taskResult = RSDTaskResultObject(identifier: "test")
         
         // Set the answer to "yes"
         answerResult.value = "true"
@@ -230,8 +230,8 @@ class SurveyNavigationRuleTests: XCTestCase {
         constraints.addRulesObject(rule)
         
         let answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .integer)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
-        var taskResult = RSDTaskResultObject(identifier: "test")
+        let stepResult = CollectionResultObject(identifier: inputStep.identifier)
+        let taskResult = RSDTaskResultObject(identifier: "test")
         
         // Set the answer to invalid
         answerResult.value = 0
@@ -264,8 +264,8 @@ class SurveyNavigationRuleTests: XCTestCase {
         constraints.addRulesObject(rule)
         
         let answerResult = RSDAnswerResultObject(identifier: inputStep.identifier, answerType: .integer)
-        var stepResult = RSDCollectionResultObject(identifier: inputStep.identifier)
-        var taskResult = RSDTaskResultObject(identifier: "test")
+        let stepResult = CollectionResultObject(identifier: inputStep.identifier)
+        let taskResult = RSDTaskResultObject(identifier: "test")
         
         // Set the answer to invalid
         answerResult.value = 1


### PR DESCRIPTION
Check that the framework builds against known ranges of versions. Fix deprecation warnings that will be introduced in version SR v4.5 (currently testing against a branch) that is not yet released.